### PR TITLE
when the OS does not have /dev/gpiomem

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -151,9 +151,6 @@ impl GPIOMem {
         // otherwise try /dev/mem instead.
         self.mem_ptr = match self.map_devgpiomem() {
             Ok(ptr) => ptr,
-            Err(e @ Error::DevGPIOMemPermissionDenied) => {
-                return Err(e);
-            }
             Err(_) => {
                 match self.map_devmem() {
                     Ok(ptr) => ptr,


### PR DESCRIPTION
when the OS does not have /dev/gpiomem
and if the application using rppal is packed in a snap
the library will return at: Err(e @ Error::DevGPIOMemPermissionDenied)
and never check if it has access to /dev/mem

This is happening because in a OS using snap (e.g. Ubuntu Core) as a packaging system you can have access to /dev/mem without having access to /dev/gpiomem because /dev/gpiomem does not exist. (see snap interfaces)

As a fix I suggest removing the lines: Err(e @ Error::DevGPIOMemPermissionDenied) => return Err(e);
