### PR TITLE
Fixes for musl libc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ script:
 env:
   - TARGET=armv7-unknown-linux-musleabihf
   - TARGET=armv7-unknown-linux-gnueabihf
+matrix:
+  allow_failures:
+  - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,15 @@
 language: rust
 services: docker
 rust:
-- stable
-- beta
-- nightly
+  - stable
+  - beta
+  - nightly
 install:
   - cargo install cross
   - source ~/.cargo/env || true
 script:
   - cross build --target $TARGET
   - cross build --target $TARGET --release
-matrix:
-  include:
-    env:
-      - TARGET=armv7-unknown-linux-gnueabihf
-      - TARGET=armv7-unknown-linux-musleabihf
-  allow_failures:
-  - rust: nightly
+env:
+  - TARGET=armv7-unknown-linux-musleabihf
+  - TARGET=armv7-unknown-linux-gnueabihf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
 language: rust
+services: docker
 rust:
 - stable
 - beta
 - nightly
+install:
+  - cargo install cross
+  - source ~/.cargo/env || true
+script:
+  - cross build --target $TARGET
+  - cross build --target $TARGET --release
 matrix:
+  include:
+    env:
+      - TARGET=armv7-unknown-linux-gnueabihf
+      - TARGET=armv7-unknown-linux-musleabihf
   allow_failures:
   - rust: nightly

--- a/src/i2c/ioctl.rs
+++ b/src/i2c/ioctl.rs
@@ -25,7 +25,12 @@ use std::io;
 use std::ptr;
 use std::result;
 
-use libc::{c_int, c_ulong, ioctl};
+use libc::{self, c_int, c_ulong, ioctl};
+
+#[cfg(target_env = "gnu")]
+type IoctlLong = libc::c_ulong;
+#[cfg(target_env = "musl")]
+type IoctlLong = libc::c_long;
 
 pub type Result<T> = result::Result<T, io::Error>;
 
@@ -200,15 +205,15 @@ impl fmt::Debug for Capabilities {
 }
 
 // ioctl() requests supported by i2cdev
-const REQ_RETRIES: c_ulong = 0x0701; // How many retries when waiting for an ACK
-const REQ_TIMEOUT: c_ulong = 0x0702; // Timeout in 10ms units
-const REQ_SLAVE: c_ulong = 0x0706; // Set slave address
-const REQ_SLAVE_FORCE: c_ulong = 0x0703; // Set slave address, even if it's already in use by a driver
-const REQ_TENBIT: c_ulong = 0x0704; // Use 10-bit slave addresses
-const REQ_FUNCS: c_ulong = 0x0705; // Read I2C bus capabilities
-const REQ_RDWR: c_ulong = 0x0707; // Combined read/write transfer with a single STOP
-const REQ_PEC: c_ulong = 0x0708; // SMBus: Use Packet Error Checking
-const REQ_SMBUS: c_ulong = 0x0720; // SMBus: Transfer data
+const REQ_RETRIES: IoctlLong = 0x0701; // How many retries when waiting for an ACK
+const REQ_TIMEOUT: IoctlLong = 0x0702; // Timeout in 10ms units
+const REQ_SLAVE: IoctlLong = 0x0706; // Set slave address
+const REQ_SLAVE_FORCE: IoctlLong = 0x0703; // Set slave address, even if it's already in use by a driver
+const REQ_TENBIT: IoctlLong = 0x0704; // Use 10-bit slave addresses
+const REQ_FUNCS: IoctlLong = 0x0705; // Read I2C bus capabilities
+const REQ_RDWR: IoctlLong = 0x0707; // Combined read/write transfer with a single STOP
+const REQ_PEC: IoctlLong = 0x0708; // SMBus: Use Packet Error Checking
+const REQ_SMBUS: IoctlLong = 0x0720; // SMBus: Transfer data
 
 // NOTE: REQ_RETRIES - Supported in i2cdev, but not used in the underlying drivers
 // NOTE: REQ_RDWR - Only a single read operation is supported as the final message (see i2c-bcm2835.c)

--- a/src/spi/ioctl.rs
+++ b/src/spi/ioctl.rs
@@ -20,12 +20,17 @@
 
 #![allow(dead_code)]
 
-use libc::{c_int, c_ulong, ioctl};
+use libc::{self, c_int, ioctl};
 use std::fmt;
 use std::io;
 use std::marker;
 use std::mem::size_of;
 use std::result;
+
+#[cfg(target_env = "gnu")]
+type IoctlLong = libc::c_ulong;
+#[cfg(target_env = "musl")]
+type IoctlLong = libc::c_long;
 
 pub type Result<T> = result::Result<T, io::Error>;
 
@@ -47,34 +52,34 @@ const TYPESHIFT: u8 = (NRSHIFT + NRBITS);
 const SIZESHIFT: u8 = (TYPESHIFT + TYPEBITS);
 const DIRSHIFT: u8 = (SIZESHIFT + SIZEBITS);
 
-const NR_MESSAGE: c_ulong = 0 << NRSHIFT;
-const NR_MODE: c_ulong = 1 << NRSHIFT;
-const NR_LSB_FIRST: c_ulong = 2 << NRSHIFT;
-const NR_BITS_PER_WORD: c_ulong = 3 << NRSHIFT;
-const NR_MAX_SPEED_HZ: c_ulong = 4 << NRSHIFT;
-const NR_MODE32: c_ulong = 5 << NRSHIFT;
+const NR_MESSAGE: IoctlLong = 0 << NRSHIFT;
+const NR_MODE: IoctlLong = 1 << NRSHIFT;
+const NR_LSB_FIRST: IoctlLong = 2 << NRSHIFT;
+const NR_BITS_PER_WORD: IoctlLong = 3 << NRSHIFT;
+const NR_MAX_SPEED_HZ: IoctlLong = 4 << NRSHIFT;
+const NR_MODE32: IoctlLong = 5 << NRSHIFT;
 
-const TYPE_SPI: c_ulong = (b'k' as c_ulong) << TYPESHIFT;
+const TYPE_SPI: IoctlLong = (b'k' as IoctlLong) << TYPESHIFT;
 
-const SIZE_U8: c_ulong = (size_of::<u8>() as c_ulong) << SIZESHIFT;
-const SIZE_U32: c_ulong = (size_of::<u32>() as c_ulong) << SIZESHIFT;
+const SIZE_U8: IoctlLong = (size_of::<u8>() as IoctlLong) << SIZESHIFT;
+const SIZE_U32: IoctlLong = (size_of::<u32>() as IoctlLong) << SIZESHIFT;
 
-const DIR_NONE: c_ulong = 0;
-const DIR_WRITE: c_ulong = 1 << DIRSHIFT;
-const DIR_READ: c_ulong = 2 << DIRSHIFT;
+const DIR_NONE: IoctlLong = 0;
+const DIR_WRITE: IoctlLong = 1 << DIRSHIFT;
+const DIR_READ: IoctlLong = 2 << DIRSHIFT;
 
-const REQ_RD_MODE: c_ulong = (DIR_READ | TYPE_SPI | NR_MODE | SIZE_U8);
-const REQ_RD_LSB_FIRST: c_ulong = (DIR_READ | TYPE_SPI | NR_LSB_FIRST | SIZE_U8);
-const REQ_RD_BITS_PER_WORD: c_ulong = (DIR_READ | TYPE_SPI | NR_BITS_PER_WORD | SIZE_U8);
-const REQ_RD_MAX_SPEED_HZ: c_ulong = (DIR_READ | TYPE_SPI | NR_MAX_SPEED_HZ | SIZE_U32);
-const REQ_RD_MODE_32: c_ulong = (DIR_READ | TYPE_SPI | NR_MODE32 | SIZE_U32);
+const REQ_RD_MODE: IoctlLong = (DIR_READ | TYPE_SPI | NR_MODE | SIZE_U8);
+const REQ_RD_LSB_FIRST: IoctlLong = (DIR_READ | TYPE_SPI | NR_LSB_FIRST | SIZE_U8);
+const REQ_RD_BITS_PER_WORD: IoctlLong = (DIR_READ | TYPE_SPI | NR_BITS_PER_WORD | SIZE_U8);
+const REQ_RD_MAX_SPEED_HZ: IoctlLong = (DIR_READ | TYPE_SPI | NR_MAX_SPEED_HZ | SIZE_U32);
+const REQ_RD_MODE_32: IoctlLong = (DIR_READ | TYPE_SPI | NR_MODE32 | SIZE_U32);
 
-const REQ_WR_MESSAGE: c_ulong = (DIR_WRITE | TYPE_SPI | NR_MESSAGE);
-const REQ_WR_MODE: c_ulong = (DIR_WRITE | TYPE_SPI | NR_MODE | SIZE_U8);
-const REQ_WR_LSB_FIRST: c_ulong = (DIR_WRITE | TYPE_SPI | NR_LSB_FIRST | SIZE_U8);
-const REQ_WR_BITS_PER_WORD: c_ulong = (DIR_WRITE | TYPE_SPI | NR_BITS_PER_WORD | SIZE_U8);
-const REQ_WR_MAX_SPEED_HZ: c_ulong = (DIR_WRITE | TYPE_SPI | NR_MAX_SPEED_HZ | SIZE_U32);
-const REQ_WR_MODE_32: c_ulong = (DIR_WRITE | TYPE_SPI | NR_MODE32 | SIZE_U32);
+const REQ_WR_MESSAGE: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_MESSAGE);
+const REQ_WR_MODE: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_MODE | SIZE_U8);
+const REQ_WR_LSB_FIRST: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_LSB_FIRST | SIZE_U8);
+const REQ_WR_BITS_PER_WORD: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_BITS_PER_WORD | SIZE_U8);
+const REQ_WR_MAX_SPEED_HZ: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_MAX_SPEED_HZ | SIZE_U32);
+const REQ_WR_MODE_32: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_MODE32 | SIZE_U32);
 
 pub const MODE_CPHA: u8 = 0x01;
 pub const MODE_CPOL: u8 = 0x02;
@@ -363,7 +368,7 @@ pub fn transfer(fd: c_int, segments: &[TransferSegment]) -> Result<i32> {
         ioctl(
             fd,
             REQ_WR_MESSAGE
-                | (((segments.len() * size_of::<TransferSegment>()) as c_ulong) << SIZESHIFT),
+                | (((segments.len() * size_of::<TransferSegment>()) as IoctlLong) << SIZESHIFT),
             segments,
         )
     })

--- a/src/uart/mod.rs
+++ b/src/uart/mod.rs
@@ -261,7 +261,7 @@ impl Uart {
     /// Support for RTS/CTS is device-dependent.
     ///
     /// [here]: index.html
-    pub fn set_hardware_flow_control(&self, enabled: bool) -> Result<()> {
+    pub fn set_hardware_flow_control(&self, _enabled: bool) -> Result<()> {
         unimplemented!()
     }
 

--- a/src/uart/termios.rs
+++ b/src/uart/termios.rs
@@ -44,6 +44,7 @@ fn parse_retval(retval: c_int) -> Result<i32> {
     }
 }
 
+#[cfg(target_env = "gnu")]
 pub fn attributes(fd: c_int) -> Result<termios> {
     let mut attr = termios {
         c_iflag: 0,
@@ -54,6 +55,24 @@ pub fn attributes(fd: c_int) -> Result<termios> {
         c_cc: [0u8; 32],
         c_ispeed: 0,
         c_ospeed: 0,
+    };
+
+    parse_retval(unsafe { tcgetattr(fd, &mut attr) })?;
+
+    Ok(attr)
+}
+
+#[cfg(target_env = "musl")]
+pub fn attributes(fd: c_int) -> Result<termios> {
+    let mut attr = termios {
+        c_iflag: 0,
+        c_oflag: 0,
+        c_cflag: 0,
+        c_lflag: 0,
+        c_line: 0,
+        c_cc: [0u8; 32],
+        __c_ispeed: 0,
+        __c_ospeed: 0,
     };
 
     parse_retval(unsafe { tcgetattr(fd, &mut attr) })?;


### PR DESCRIPTION
I was playing with my Raspberry Pi and the `musl` libc, and realized `rppal` wouldn't build.

I made sure it still builds with the regular GNU `glibc` and tested on `musl` with [cross](https://github.com/rust-embedded/cross) by running `cross build  --target=armv7-unknown-linux-musleabihf`.

I'm not sure it's something you want. If you do: I can absolutely rename the alias type or do it in a different way if you wish.