### PR TITLE
Refactoring.

### DIFF
--- a/src/gpio/interrupt.rs
+++ b/src/gpio/interrupt.rs
@@ -40,9 +40,7 @@ impl Interrupt {
     fn new(fd: i32, pin: u8, trigger: Trigger) -> Result<Interrupt> {
         let chip_info = ioctl::ChipInfo::new(fd)?;
 
-        if u32::from(pin) > chip_info.lines {
-            return Err(Error::InvalidPin(pin));
-        }
+        assert_pin!(pin as u32, chip_info.lines);
 
         let event_request = ioctl::EventRequest::new(fd, pin, trigger)?;
 
@@ -155,9 +153,7 @@ impl EventLoop {
         timeout: Option<Duration>,
     ) -> Result<Option<(u8, Level)>> {
         for pin in pins {
-            if *pin as usize >= self.trigger_status.capacity() {
-                return Err(Error::InvalidPin(*pin));
-            }
+            assert_pin!(*pin as usize, self.trigger_status.capacity());
 
             // Did we cache any trigger events during the previous poll?
             if self.trigger_status[*pin as usize].triggered {

--- a/src/gpio/ioctl.rs
+++ b/src/gpio/ioctl.rs
@@ -333,9 +333,7 @@ pub fn find_driver() -> Result<File> {
 pub fn get_level(cdev_fd: c_int, pin: u8) -> Result<Level> {
     let chip_info = ChipInfo::new(cdev_fd)?;
 
-    if u32::from(pin) > chip_info.lines {
-        return Err(Error::InvalidPin(pin));
-    }
+    assert_pin!(pin as u32, chip_info.lines);
 
     match HandleRequest::new(cdev_fd, &[pin])?.levels()?.values[0] {
         0 => Ok(Level::Low),

--- a/src/gpio/ioctl.rs
+++ b/src/gpio/ioctl.rs
@@ -34,14 +34,6 @@ type IoctlLong = libc::c_ulong;
 #[cfg(target_env = "musl")]
 type IoctlLong = libc::c_long;
 
-fn parse_retval(retval: c_int) -> Result<i32> {
-    if retval == -1 {
-        Err(Error::Io(io::Error::last_os_error()))
-    } else {
-        Ok(retval)
-    }
-}
-
 const NRBITS: u8 = 8;
 const TYPEBITS: u8 = 8;
 const SIZEBITS: u8 = 14;
@@ -102,7 +94,7 @@ impl ChipInfo {
             lines: 0,
         };
 
-        parse_retval(unsafe { ioctl(cdev_fd, REQ_GET_CHIP_INFO, &mut chip_info) })?;
+        parse_retval!(unsafe { ioctl(cdev_fd, REQ_GET_CHIP_INFO, &mut chip_info) })?;
 
         Ok(chip_info)
     }
@@ -175,7 +167,7 @@ impl HandleRequest {
             handle_request.line_offsets[idx] = u32::from(*pin);
         }
 
-        parse_retval(unsafe { ioctl(cdev_fd, REQ_GET_LINE_HANDLE, &mut handle_request) })?;
+        parse_retval!(unsafe { ioctl(cdev_fd, REQ_GET_LINE_HANDLE, &mut handle_request) })?;
 
         Ok(handle_request)
     }
@@ -183,7 +175,7 @@ impl HandleRequest {
     pub fn levels(&self) -> Result<HandleData> {
         let mut handle_data = HandleData::new();
 
-        parse_retval(unsafe { ioctl(self.fd, REQ_GET_LINE_VALUES, &mut handle_data) })?;
+        parse_retval!(unsafe { ioctl(self.fd, REQ_GET_LINE_VALUES, &mut handle_data) })?;
 
         Ok(handle_data)
     }
@@ -200,7 +192,7 @@ impl HandleRequest {
             handle_data.values[idx] = *level as u8;
         }
 
-        parse_retval(unsafe { ioctl(self.fd, REQ_SET_LINE_VALUES, &mut handle_data) })?;
+        parse_retval!(unsafe { ioctl(self.fd, REQ_SET_LINE_VALUES, &mut handle_data) })?;
 
         Ok(())
     }
@@ -244,7 +236,7 @@ impl EventRequest {
             fd: 0,
         };
 
-        parse_retval(unsafe { ioctl(cdev_fd, REQ_GET_LINE_EVENT, &mut event_request) })?;
+        parse_retval!(unsafe { ioctl(cdev_fd, REQ_GET_LINE_EVENT, &mut event_request) })?;
 
         Ok(event_request)
     }
@@ -267,7 +259,7 @@ impl EventData {
             id: 0,
         };
 
-        let bytes_read = parse_retval(unsafe {
+        let bytes_read = parse_retval!(unsafe {
             read(
                 event_fd,
                 &mut event_data as *mut EventData as *mut c_void,

--- a/src/gpio/ioctl.rs
+++ b/src/gpio/ioctl.rs
@@ -338,8 +338,9 @@ pub fn get_level(cdev_fd: c_int, pin: u8) -> Result<Level> {
     }
 
     match HandleRequest::new(cdev_fd, &[pin])?.levels()?.values[0] {
+        0 => Ok(Level::Low),
         1 => Ok(Level::High),
-        _ => Ok(Level::Low),
+        _ => unreachable!(),
     }
 }
 

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -60,7 +60,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::sleep;
 use std::time::Duration;
 
-#[macro_export]
 macro_rules! assert_pin {
   ($pin:expr) => {{
       assert_pin!($pin, GPIO_MAX_PINS);

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -67,7 +67,7 @@ macro_rules! assert_pin {
   }};
   ($pin:expr, $count:expr) => {{
     if ($pin) >= ($count) {
-        panic!("GPIO pin {} does not exist.", $pin);
+        return Err(Error::InvalidPin($pin as u8))
     }
   }};
 }
@@ -132,14 +132,6 @@ quick_error! {
 ///
 /// [`Gpio`]: struct.Gpio.html
         InstanceExists { description("an instance of Gpio already exists") }
-/// [`Gpio`] isn't initialized.
-///
-/// You should normally only see this error when you call a method after
-/// running [`cleanup`].
-///
-/// [`cleanup`]: struct.Gpio.html#method.cleanup
-/// [`Gpio`]: struct.Gpio.html
-        NotInitialized { description("not initialized") }
 /// IO error.
         Io(err: io::Error) { description(err.description()) from() }
 /// Interrupt polling thread panicked.
@@ -340,33 +332,29 @@ impl Gpio {
     /// scope, but you can manually call it to handle early/abnormal termination.
     /// After calling this method, any future calls to other methods won't have any
     /// result.
-    pub fn cleanup(mut self) {
+    pub fn cleanup(mut self) -> Result<()> {
         self.cleanup_internal()
     }
 
-    fn cleanup_internal(&mut self) {
+    fn cleanup_internal(&mut self) -> Result<()> {
         // Use a cloned copy, because set_mode() will try to change
         // the contents of the original vector.
         for pin_state in &self.orig_pin_state.clone() {
             if pin_state.changed {
-                self.set_mode(pin_state.pin, pin_state.mode);
+                self.set_mode(pin_state.pin, pin_state.mode)?;
             }
         }
 
         self.gpio_mem.close();
 
-        self.initialized = false
+        self.initialized = false;
+
+        Ok(())
     }
 
     /// Gets the current GPIO pin mode.
     pub fn mode(&self, pin: u8) -> Result<Mode> {
-        if !self.initialized {
-            return Err(Error::NotInitialized);
-        }
-
-        if pin >= GPIO_MAX_PINS {
-            return Err(Error::InvalidPin(pin));
-        }
+        assert_pin!(pin);
 
         let reg_addr: usize = GPIO_OFFSET_GPFSEL + (pin / 10) as usize;
         let reg_value = self.gpio_mem.read(reg_addr);
@@ -396,10 +384,8 @@ impl Gpio {
     /// [`BCM2835`] documentation.
     ///
     /// [`BCM2835`]: https://www.raspberrypi.org/app/uploads/2012/02/BCM2835-ARM-Peripherals.pdf
-    pub fn set_mode(&mut self, pin: u8, mode: Mode) {
-        if !self.initialized || (pin >= GPIO_MAX_PINS) {
-            return;
-        }
+    pub fn set_mode(&mut self, pin: u8, mode: Mode) -> Result<()> {
+        assert_pin!(pin);
 
         // Keep track of our mode changes, so we can revert them in cleanup()
         if let Some(pin_state) = self.orig_pin_state.get_mut(pin as usize) {
@@ -416,17 +402,13 @@ impl Gpio {
             (reg_value & !(0b111 << ((pin % 10) * 3)))
                 | ((mode as u32 & 0b111) << ((pin % 10) * 3)),
         );
+
+        Ok(())
     }
 
     /// Reads the current GPIO pin logic level.
     pub fn read(&self, pin: u8) -> Result<Level> {
-        if !self.initialized {
-            return Err(Error::NotInitialized);
-        }
-
-        if pin >= GPIO_MAX_PINS {
-            return Err(Error::InvalidPin(pin));
-        }
+        assert_pin!(pin);
 
         let reg_addr: usize = GPIO_OFFSET_GPLEV + (pin / 32) as usize;
         let reg_value = self.gpio_mem.read(reg_addr);
@@ -439,10 +421,8 @@ impl Gpio {
     }
 
     /// Changes the GPIO pin logic level to high or low.
-    pub fn write(&self, pin: u8, level: Level) {
-        if !self.initialized || (pin >= GPIO_MAX_PINS) {
-            return;
-        }
+    pub fn write(&self, pin: u8, level: Level) -> Result<()> {
+        assert_pin!(pin);
 
         let reg_addr: usize = match level {
             Level::Low => GPIO_OFFSET_GPCLR + (pin / 32) as usize,
@@ -450,13 +430,13 @@ impl Gpio {
         };
 
         self.gpio_mem.write(reg_addr, 1 << (pin % 32));
+
+        Ok(())
     }
 
     /// Configures the built-in GPIO pull-up/pull-down resistors.
-    pub fn set_pullupdown(&self, pin: u8, pud: PullUpDown) {
-        if !self.initialized || (pin >= GPIO_MAX_PINS) {
-            return;
-        }
+    pub fn set_pullupdown(&self, pin: u8, pud: PullUpDown) -> Result<()> {
+        assert_pin!(pin);
 
         // Set the control signal in GPPUD, while leaving the other 30
         // bits unchanged.
@@ -483,6 +463,8 @@ impl Gpio {
         let reg_value = self.gpio_mem.read(GPIO_OFFSET_GPPUD);
         self.gpio_mem.write(GPIO_OFFSET_GPPUD, reg_value & !0b11);
         self.gpio_mem.write(reg_addr, 0 << (pin % 32));
+
+        Ok(())
     }
 
     /// Configures a synchronous interrupt trigger.
@@ -495,36 +477,20 @@ impl Gpio {
     ///
     /// [`poll_interrupt`]: #method.poll_interrupt
     pub fn set_interrupt(&mut self, pin: u8, trigger: Trigger) -> Result<()> {
-        if !self.initialized {
-            return Err(Error::NotInitialized);
-        }
-
-        if pin >= GPIO_MAX_PINS {
-            return Err(Error::InvalidPin(pin));
-        }
+        assert_pin!(pin);
 
         // We can't have sync and async interrupts on the same pin at the same time
         self.clear_async_interrupt(pin)?;
 
         // Each pin can only be configured for a single trigger type
-        self.sync_interrupts.set_interrupt(pin, trigger)?;
-
-        Ok(())
+        self.sync_interrupts.set_interrupt(pin, trigger)
     }
 
     /// Removes a previously configured synchronous interrupt trigger.
     pub fn clear_interrupt(&mut self, pin: u8) -> Result<()> {
-        if !self.initialized {
-            return Err(Error::NotInitialized);
-        }
+        assert_pin!(pin);
 
-        if pin >= GPIO_MAX_PINS {
-            return Err(Error::InvalidPin(pin));
-        }
-
-        self.sync_interrupts.clear_interrupt(pin)?;
-
-        Ok(())
+        self.sync_interrupts.clear_interrupt(pin)
     }
 
     /// Blocks until an interrupt is triggered on the specified pin, or a timeout occurs.
@@ -547,13 +513,12 @@ impl Gpio {
         reset: bool,
         timeout: Option<Duration>,
     ) -> Result<Option<Level>> {
-        match self.poll_interrupts(&[pin], reset, timeout) {
-            Ok(opt) => if let Some(trigger) = opt {
-                Ok(Some(trigger.1))
-            } else {
-                Ok(None)
-            },
-            Err(e) => Err(e),
+        let opt = self.poll_interrupts(&[pin], reset, timeout)?;
+
+        if let Some(trigger) = opt {
+            Ok(Some(trigger.1))
+        } else {
+            Ok(None)
         }
     }
 
@@ -582,17 +547,11 @@ impl Gpio {
         reset: bool,
         timeout: Option<Duration>,
     ) -> Result<Option<(u8, Level)>> {
-        if !self.initialized {
-            return Err(Error::NotInitialized);
-        }
-
         for pin in pins {
-            if *pin >= GPIO_MAX_PINS {
-                return Err(Error::InvalidPin(*pin));
-            }
+            assert_pin!(*pin);
         }
 
-        Ok(self.sync_interrupts.poll(pins, reset, timeout)?)
+        self.sync_interrupts.poll(pins, reset, timeout)
     }
 
     /// Configures an asynchronous interrupt trigger, which will execute the callback on a
@@ -608,13 +567,7 @@ impl Gpio {
     where
         C: FnMut(Level) + Send + 'static,
     {
-        if !self.initialized {
-            return Err(Error::NotInitialized);
-        }
-
-        if pin >= GPIO_MAX_PINS {
-            return Err(Error::InvalidPin(pin));
-        }
+        assert_pin!(pin);
 
         // We can't have sync and async interrupts on the same pin at the same time
         self.clear_interrupt(pin)?;
@@ -634,13 +587,7 @@ impl Gpio {
 
     /// Removes a previously configured asynchronous interrupt trigger.
     pub fn clear_async_interrupt(&mut self, pin: u8) -> Result<()> {
-        if !self.initialized {
-            return Err(Error::NotInitialized);
-        }
-
-        if pin >= GPIO_MAX_PINS {
-            return Err(Error::InvalidPin(pin));
-        }
+        assert_pin!(pin);
 
         if let Some(mut interrupt) = self.async_interrupts[pin as usize].take() {
             // stop() blocks until the poll thread exits
@@ -654,7 +601,7 @@ impl Gpio {
 impl Drop for Gpio {
     fn drop(&mut self) {
         if self.clear_on_drop && self.initialized {
-            self.cleanup_internal();
+            let _ = self.cleanup_internal();
         }
 
         unsafe {

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -60,6 +60,18 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::sleep;
 use std::time::Duration;
 
+#[macro_export]
+macro_rules! assert_pin {
+  ($pin:expr) => {{
+      assert_pin!($pin, GPIO_MAX_PINS);
+  }};
+  ($pin:expr, $count:expr) => {{
+    if ($pin) >= ($count) {
+        panic!("GPIO pin {} does not exist.", $pin);
+    }
+  }};
+}
+
 mod epoll;
 mod interrupt;
 mod ioctl;

--- a/src/i2c/ioctl.rs
+++ b/src/i2c/ioctl.rs
@@ -32,14 +32,6 @@ type IoctlLong = libc::c_long;
 
 pub type Result<T> = result::Result<T, io::Error>;
 
-fn parse_retval(retval: c_int) -> Result<i32> {
-    if retval == -1 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(retval)
-    }
-}
-
 // Based on i2c.h, i2c-dev.c, i2c-dev.h and the documentation at https://www.kernel.org/doc/Documentation/i2c
 // and http://smbus.org/specs/SMBus_3_1_20180319.pdf
 
@@ -327,7 +319,7 @@ fn smbus_request(
         },
     };
 
-    parse_retval(unsafe { ioctl(fd, REQ_SMBUS, &mut request) })?;
+    parse_retval!(unsafe { ioctl(fd, REQ_SMBUS, &mut request) })?;
 
     Ok(())
 }
@@ -559,25 +551,25 @@ pub fn i2c_write_read(
         nmsgs: 2,
     };
 
-    parse_retval(unsafe { ioctl(fd, REQ_RDWR, &mut request) })?;
+    parse_retval!(unsafe { ioctl(fd, REQ_RDWR, &mut request) })?;
 
     Ok(())
 }
 
 pub fn set_slave_address(fd: c_int, value: c_ulong) -> Result<()> {
-    parse_retval(unsafe { ioctl(fd, REQ_SLAVE, value) })?;
+    parse_retval!(unsafe { ioctl(fd, REQ_SLAVE, value) })?;
 
     Ok(())
 }
 
 pub fn set_addr_10bit(fd: c_int, value: c_ulong) -> Result<()> {
-    parse_retval(unsafe { ioctl(fd, REQ_TENBIT, value) })?;
+    parse_retval!(unsafe { ioctl(fd, REQ_TENBIT, value) })?;
 
     Ok(())
 }
 
 pub fn set_pec(fd: c_int, value: c_ulong) -> Result<()> {
-    parse_retval(unsafe { ioctl(fd, REQ_PEC, value) })?;
+    parse_retval!(unsafe { ioctl(fd, REQ_PEC, value) })?;
 
     Ok(())
 }
@@ -590,14 +582,14 @@ pub fn set_timeout(fd: c_int, value: c_ulong) -> Result<()> {
         value / 10
     };
 
-    parse_retval(unsafe { ioctl(fd, REQ_TIMEOUT, timeout) })?;
+    parse_retval!(unsafe { ioctl(fd, REQ_TIMEOUT, timeout) })?;
 
     Ok(())
 }
 
 pub fn set_retries(fd: c_int, value: c_ulong) -> Result<()> {
     // Number of retries on arbitration loss
-    parse_retval(unsafe { ioctl(fd, REQ_RETRIES, value) })?;
+    parse_retval!(unsafe { ioctl(fd, REQ_RETRIES, value) })?;
 
     Ok(())
 }
@@ -605,7 +597,7 @@ pub fn set_retries(fd: c_int, value: c_ulong) -> Result<()> {
 pub fn funcs(fd: c_int) -> Result<Capabilities> {
     let mut funcs: c_ulong = 0;
 
-    parse_retval(unsafe { ioctl(fd, REQ_FUNCS, &mut funcs) })?;
+    parse_retval!(unsafe { ioctl(fd, REQ_FUNCS, &mut funcs) })?;
 
     Ok(Capabilities::new(funcs))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ extern crate quick_error;
 
 mod user;
 
+#[macro_use]
 pub mod gpio;
 pub mod i2c;
 pub mod pwm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@ extern crate quick_error;
 mod user;
 
 #[macro_use]
+mod macros;
+
 pub mod gpio;
 pub mod i2c;
 pub mod pwm;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,11 @@
+macro_rules! parse_retval {
+  ($retval:expr) => {{
+    let retval = $retval;
+
+    if retval == -1 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(retval)
+    }
+  }};
+}

--- a/src/spi/ioctl.rs
+++ b/src/spi/ioctl.rs
@@ -34,14 +34,6 @@ type IoctlLong = libc::c_long;
 
 pub type Result<T> = result::Result<T, io::Error>;
 
-fn parse_retval(retval: c_int) -> Result<i32> {
-    if retval == -1 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(retval)
-    }
-}
-
 const NRBITS: u8 = 8;
 const TYPEBITS: u8 = 8;
 const SIZEBITS: u8 = 14;
@@ -324,47 +316,47 @@ impl<'a, 'b> fmt::Debug for TransferSegment<'a, 'b> {
 }
 
 pub fn mode(fd: c_int, value: &mut u8) -> Result<i32> {
-    parse_retval(unsafe { ioctl(fd, REQ_RD_MODE, value) })
+    parse_retval!(unsafe { ioctl(fd, REQ_RD_MODE, value) })
 }
 
 pub fn set_mode(fd: c_int, value: u8) -> Result<i32> {
-    parse_retval(unsafe { ioctl(fd, REQ_WR_MODE, &value) })
+    parse_retval!(unsafe { ioctl(fd, REQ_WR_MODE, &value) })
 }
 
 pub fn lsb_first(fd: c_int, value: &mut u8) -> Result<i32> {
-    parse_retval(unsafe { ioctl(fd, REQ_RD_LSB_FIRST, value) })
+    parse_retval!(unsafe { ioctl(fd, REQ_RD_LSB_FIRST, value) })
 }
 
 pub fn set_lsb_first(fd: c_int, value: u8) -> Result<i32> {
-    parse_retval(unsafe { ioctl(fd, REQ_WR_LSB_FIRST, &value) })
+    parse_retval!(unsafe { ioctl(fd, REQ_WR_LSB_FIRST, &value) })
 }
 
 pub fn bits_per_word(fd: c_int, value: &mut u8) -> Result<i32> {
-    parse_retval(unsafe { ioctl(fd, REQ_RD_BITS_PER_WORD, value) })
+    parse_retval!(unsafe { ioctl(fd, REQ_RD_BITS_PER_WORD, value) })
 }
 
 pub fn set_bits_per_word(fd: c_int, value: u8) -> Result<i32> {
-    parse_retval(unsafe { ioctl(fd, REQ_WR_BITS_PER_WORD, &value) })
+    parse_retval!(unsafe { ioctl(fd, REQ_WR_BITS_PER_WORD, &value) })
 }
 
 pub fn clock_speed(fd: c_int, value: &mut u32) -> Result<i32> {
-    parse_retval(unsafe { ioctl(fd, REQ_RD_MAX_SPEED_HZ, value) })
+    parse_retval!(unsafe { ioctl(fd, REQ_RD_MAX_SPEED_HZ, value) })
 }
 
 pub fn set_clock_speed(fd: c_int, value: u32) -> Result<i32> {
-    parse_retval(unsafe { ioctl(fd, REQ_WR_MAX_SPEED_HZ, &value) })
+    parse_retval!(unsafe { ioctl(fd, REQ_WR_MAX_SPEED_HZ, &value) })
 }
 
 pub fn mode32(fd: c_int, value: &mut u32) -> Result<i32> {
-    parse_retval(unsafe { ioctl(fd, REQ_RD_MODE_32, value) })
+    parse_retval!(unsafe { ioctl(fd, REQ_RD_MODE_32, value) })
 }
 
 pub fn set_mode32(fd: c_int, value: u32) -> Result<i32> {
-    parse_retval(unsafe { ioctl(fd, REQ_WR_MODE_32, &value) })
+    parse_retval!(unsafe { ioctl(fd, REQ_WR_MODE_32, &value) })
 }
 
 pub fn transfer(fd: c_int, segments: &[TransferSegment]) -> Result<i32> {
-    parse_retval(unsafe {
+    parse_retval!(unsafe {
         ioctl(
             fd,
             REQ_WR_MESSAGE

--- a/src/uart/termios.rs
+++ b/src/uart/termios.rs
@@ -36,14 +36,6 @@ use libc::{VMIN, VTIME};
 
 use uart::{Error, Parity, Result};
 
-fn parse_retval(retval: c_int) -> Result<i32> {
-    if retval == -1 {
-        Err(Error::Io(io::Error::last_os_error()))
-    } else {
-        Ok(retval)
-    }
-}
-
 #[cfg(target_env = "gnu")]
 pub fn attributes(fd: c_int) -> Result<termios> {
     let mut attr = termios {
@@ -57,7 +49,7 @@ pub fn attributes(fd: c_int) -> Result<termios> {
         c_ospeed: 0,
     };
 
-    parse_retval(unsafe { tcgetattr(fd, &mut attr) })?;
+    parse_retval!(unsafe { tcgetattr(fd, &mut attr) })?;
 
     Ok(attr)
 }
@@ -75,13 +67,13 @@ pub fn attributes(fd: c_int) -> Result<termios> {
         __c_ospeed: 0,
     };
 
-    parse_retval(unsafe { tcgetattr(fd, &mut attr) })?;
+    parse_retval!(unsafe { tcgetattr(fd, &mut attr) })?;
 
     Ok(attr)
 }
 
 pub fn set_attributes(fd: c_int, attr: &termios) -> Result<()> {
-    parse_retval(unsafe { tcsetattr(fd, TCSANOW, attr) })?;
+    parse_retval!(unsafe { tcsetattr(fd, TCSANOW, attr) })?;
 
     Ok(())
 }
@@ -160,8 +152,8 @@ pub fn set_line_speed(fd: c_int, line_speed: u32) -> Result<()> {
     };
 
     let mut attr = attributes(fd)?;
-    parse_retval(unsafe { cfsetispeed(&mut attr, baud) })?;
-    parse_retval(unsafe { cfsetospeed(&mut attr, baud) })?;
+    parse_retval!(unsafe { cfsetispeed(&mut attr, baud) })?;
+    parse_retval!(unsafe { cfsetospeed(&mut attr, baud) })?;
     set_attributes(fd, &attr)?;
 
     Ok(())


### PR DESCRIPTION
This includes the following changes:

- Use `connect/create` instead of `new` for constructors which return a `Result`, to make this more idiomatic (similar to `File::create`).
- Change `Gpio::cleanup` from `&mut self` to `mut self`. This way the compiler ensures the `Gpio` is still initialized, instead of the programmer having to deal with `Error::NotInitialized`.
- Treat invalid pins as a programming error, i.e. panic if the given pin doesn't exist. (Similar to how an index error on `Vec::insert` is treated.)
  - This also makes `read` and `write` more symmetric, since previously `write` would simply return without any error, while `read` would return a `Result`.
- Convert `parse_retval` to a macro.