### PR TITLE
Per-pin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,45 +65,39 @@ Add a dependency for `rppal` to your `Cargo.toml`.
 rppal = "0.9"
 ```
 
-Link and import `rppal` from your crate root.
-
-```rust
-extern crate rppal;
-```
-
 Call `Gpio::new()` to create a new Gpio instance with the default settings. In production code, you'll want to parse the result rather than unwrap it.
 
 ```rust
 use rppal::gpio::Gpio;
 
-let mut gpio = Gpio::new().unwrap();
+let gpio = Gpio::new().unwrap();
 ```
 
 ## Example
 
 ```rust
-extern crate rppal;
-
-use std::thread;
+use std::thread::sleep;
 use std::time::Duration;
 
-use rppal::gpio::{Gpio, Mode, Level};
+use rppal::gpio::Gpio;
 use rppal::system::DeviceInfo;
 
-// The GPIO module uses BCM pin numbering. BCM GPIO 18 is tied to physical pin 12.
+// The `Gpio` module uses BCM pin numbering. BCM GPIO 18 is tied to physical pin 12.
 const GPIO_LED: u8 = 18;
 
 fn main() {
     let device_info = DeviceInfo::new().unwrap();
     println!("Model: {} (SoC: {})", device_info.model(), device_info.soc());
 
-    let mut gpio = Gpio::new().unwrap();
-    gpio.set_mode(GPIO_LED, Mode::Output);
+    let gpio = Gpio::new().unwrap();
+    
+    let mut pin = gpio.get_pin(GPIO_LED).unwrap();
+    let mut output_pin = pin.as_output();
 
-    // Blink an LED attached to the pin on and off
-    gpio.write(GPIO_LED, Level::High);
-    thread::sleep(Duration::from_millis(500));
-    gpio.write(GPIO_LED, Level::Low);
+    // Blink an LED attached to the pin.
+    output_pin.set_high();
+    sleep(Duration::from_millis(500));
+    output_pin.set_low();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ fn main() {
 
     let gpio = Gpio::new().unwrap();
     
-    let mut pin = gpio.get_pin(GPIO_LED).unwrap();
+    let mut pin = gpio.get(GPIO_LED).unwrap();
     let mut output_pin = pin.as_output();
 
     // Blink an LED attached to the pin.

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -272,7 +272,7 @@ impl Gpio {
         let cdev = ioctl::find_driver()?;
         let cdev_fd = cdev.as_raw_fd();
 
-        let cdev = Arc::new(Mutex::new(cdev));
+        let cdev = Arc::new(cdev);
         let event_loop = Arc::new(Mutex::new(interrupt::EventLoop::new(cdev_fd, GPIO_MAX_PINS as usize)?));
         let gpio_mem = Arc::new(mem::GpioMem::open()?);
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -299,25 +299,11 @@ impl Gpio {
     /// [`set_interrupt`]: #method.set_interrupt
     pub fn poll_interrupts<'a>(
       &self,
-      pins: &'a[&'a InputPin<'a>],
+      pins: &[&'a InputPin<'a>],
       reset: bool,
       timeout: Option<Duration>,
     ) -> Result<Option<(&'a InputPin<'a>, Level)>> {
-      let pin_ids: Vec<u8> = pins.iter().map(|pin| pin.pin.pin).collect();
-
-      match (*self.sync_interrupts.lock().unwrap()).poll(&pin_ids, reset, timeout) {
-        Ok(Some((pin_id, level))) => {
-          for pin in pins {
-            if pin.pin.pin == pin_id {
-              return Ok(Some((pin, level)))
-            }
-          }
-
-          unsafe { std::hint::unreachable_unchecked() }
-        },
-        Ok(None) => Ok(None),
-        Err(err) => Err(err),
-      }
+      (*self.sync_interrupts.lock().unwrap()).poll(pins, reset, timeout)
     }
   }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -147,31 +147,16 @@ pub type Result<T> = result::Result<T, Error>;
 
 /// Pin modes.
 #[derive(Debug, PartialEq, Copy, Clone)]
+#[repr(u8)]
 pub enum Mode {
     Input = 0b000,
     Output = 0b001,
-    Alt5   = 0b010, // PWM
-    Alt4   = 0b011, // SPI
-    Alt0   = 0b100, // PCM
-    Alt1   = 0b101, // SMI
-    Alt2   = 0b110, // ---
-    Alt3   = 0b111, // BSC-SPI
-}
-
-impl From<u8> for Mode {
-    fn from(mode: u8) -> Mode {
-        match mode {
-            0b000 => Mode::Input,
-            0b001 => Mode::Output,
-            0b010 => Mode::Alt5,
-            0b011 => Mode::Alt4,
-            0b100 => Mode::Alt0,
-            0b101 => Mode::Alt1,
-            0b110 => Mode::Alt2,
-            0b111 => Mode::Alt3,
-            _ => unreachable!(),
-        }
-    }
+    Alt5 = 0b010, // PWM
+    Alt4 = 0b011, // SPI
+    Alt0 = 0b100, // PCM
+    Alt1 = 0b101, // SMI
+    Alt2 = 0b110, // ---
+    Alt3 = 0b111, // BSC-SPI
 }
 
 impl fmt::Display for Mode {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -76,14 +76,6 @@ quick_error! {
 /// Errors that can occur when accessing the GPIO peripheral.
     #[derive(Debug)]
     pub enum Error {
-/// Invalid GPIO pin number.
-///
-/// The GPIO pin number is not available on this Raspberry Pi model.
-        InvalidPin(pin: u8) { description("invalid GPIO pin number") }
-/// Unknown GPIO pin mode.
-///
-/// The GPIO pin is set to an unknown mode.
-        UnknownMode(mode: u8) { description("unknown mode") }
 /// Unknown SoC.
 ///
 /// It wasn't possible to automatically identify the Raspberry Pi's SoC.

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -401,25 +401,6 @@ impl Gpio {
         Ok(())
     }
 
-    /// Configures a synchronous interrupt trigger.
-    ///
-    /// After configuring a synchronous interrupt trigger, you can use
-    /// [`poll_interrupt`] to wait for a trigger event.
-    ///
-    /// `set_interrupt` will remove any previously configured
-    /// (a)synchronous interrupt triggers for the same pin.
-    ///
-    /// [`poll_interrupt`]: #method.poll_interrupt
-    pub fn set_interrupt(&mut self, pin: u8, trigger: Trigger) -> Result<()> {
-        assert_pin!(pin);
-
-        // We can't have sync and async interrupts on the same pin at the same time
-        self.clear_async_interrupt(pin)?;
-
-        // Each pin can only be configured for a single trigger type
-        (*self.sync_interrupts.lock().unwrap()).set_interrupt(pin, trigger)
-    }
-
     /// Removes a previously configured synchronous interrupt trigger.
     pub fn clear_interrupt(&mut self, pin: u8) -> Result<()> {
         assert_pin!(pin);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -314,26 +314,6 @@ impl Gpio {
         }
     }
 
-    /// Returns the value of `clear_on_drop`.
-    pub fn clear_on_drop(&self) -> bool {
-        self.clear_on_drop
-    }
-
-    /// When enabled, resets all pins to their original state when `Gpio` goes out of scope.
-    ///
-    /// Drop methods aren't called when a program is abnormally terminated,
-    /// for instance when a user presses Ctrl-C, and the SIGINT signal isn't
-    /// caught. You'll either have to catch those using crates such as
-    /// [`simple_signal`], or manually call [`cleanup`].
-    ///
-    /// By default, `clear_on_drop` is set to `true`.
-    ///
-    /// [`simple_signal`]: https://crates.io/crates/simple-signal
-    /// [`cleanup`]: #method.cleanup
-    pub fn set_clear_on_drop(&mut self, clear_on_drop: bool) {
-        self.clear_on_drop = clear_on_drop;
-    }
-
     /// Blocks until a synchronous interrupt is triggered on any of the specified pins, or a timeout occurs.
     ///
     /// `poll_interrupts` only works for pins that have been configured for synchronous interrupts using

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -246,7 +246,7 @@ impl fmt::Display for Trigger {
 /// Provides access to the Raspberry Pi's GPIO peripheral.
 pub struct Gpio {
     clear_on_drop: bool,
-    pub(crate) gpio_mem: Arc<Mutex<mem::GpioMem>>,
+    pub(crate) gpio_mem: Arc<mem::GpioMem>,
     pins: [Arc<Mutex<pin::Pin>>; GPIO_MAX_PINS as usize],
     sync_interrupts: Arc<Mutex<interrupt::EventLoop>>,
 }
@@ -274,7 +274,7 @@ impl Gpio {
 
         let cdev = Arc::new(Mutex::new(cdev));
         let event_loop = Arc::new(Mutex::new(interrupt::EventLoop::new(cdev_fd, GPIO_MAX_PINS as usize)?));
-        let gpio_mem = Arc::new(Mutex::new(mem::GpioMem::open()?));
+        let gpio_mem = Arc::new(mem::GpioMem::open()?);
 
         let pins = unsafe {
             let mut pins: [Arc<Mutex<pin::Pin>>; GPIO_MAX_PINS as usize] = std::mem::uninitialized();

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -277,9 +277,7 @@ impl Gpio {
 
         let cdev = Arc::new(Mutex::new(cdev));
         let event_loop = Arc::new(Mutex::new(interrupt::EventLoop::new(cdev_fd, GPIO_MAX_PINS as usize)?));
-        let gpio_mem = Arc::new(Mutex::new(mem::GpioMem::new()));
-
-        (*gpio_mem.lock().unwrap()).open()?;
+        let gpio_mem = Arc::new(Mutex::new(mem::GpioMem::open()?));
 
         let pins = unsafe {
             let mut pins: [Arc<Mutex<pin::Pin>>; GPIO_MAX_PINS as usize] = std::mem::uninitialized();
@@ -357,8 +355,6 @@ impl Gpio {
     }
 
     fn cleanup_internal(&mut self) -> Result<()> {
-        (*self.gpio_mem.lock().unwrap()).close();
-
         self.initialized = false;
 
         Ok(())

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -61,7 +61,7 @@
 //! ```
 //! # use std::{time::Duration, thread::sleep};
 //! let gpio = Gpio::new()?;
-//! let mut pin = *gpio.get_pin(23);
+//! let mut pin = *gpio.get(23);
 //! let mut output_pin = pin.as_output();
 //!
 //! output_pin.set_high();
@@ -282,7 +282,7 @@ impl Gpio {
         Ok(gpio)
     }
 
-    pub fn get_pin(&self, pin: u8) -> Option<MutexGuard<pin::Pin>> {
+    pub fn get(&self, pin: u8) -> Option<MutexGuard<pin::Pin>> {
         if pin as usize >= pin::MAX {
             None
         } else {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -67,7 +67,7 @@ mod ioctl;
 mod mem;
 mod pin;
 
-pub use self::pin::{InputPin, OutputPin};
+pub use self::pin::{Pin, InputPin, OutputPin, AltPin};
 
 // Used to limit Gpio to a single instance
 static mut GPIO_INSTANCED: AtomicBool = AtomicBool::new(false);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -176,6 +176,7 @@ impl fmt::Display for Mode {
 
 /// Pin logic levels.
 #[derive(Debug, PartialEq, Copy, Clone)]
+#[repr(u8)]
 pub enum Level {
     Low = 0,
     High = 1,

--- a/src/gpio/epoll.rs
+++ b/src/gpio/epoll.rs
@@ -25,6 +25,7 @@ use std::result;
 use std::time::Duration;
 
 use libc;
+use libc::c_int;
 
 pub use libc::{epoll_event, EPOLLERR, EPOLLET, EPOLLIN, EPOLLONESHOT, EPOLLOUT, EPOLLPRI};
 
@@ -120,14 +121,14 @@ impl Epoll {
             return Ok(0);
         }
 
-        let timeout: i32 = if let Some(duration) = timeout {
-            (duration.as_secs() * 1_000) as i32 + duration.subsec_millis() as i32
+        let timeout = if let Some(duration) = timeout {
+            (duration.as_secs() * 1_000 + duration.subsec_millis() as u64) as c_int
         } else {
             -1
         };
 
         Ok(parse_retval!(unsafe {
-            libc::epoll_wait(self.fd, events.as_mut_ptr(), events.len() as i32, timeout)
+            libc::epoll_wait(self.fd, events.as_mut_ptr(), events.len() as c_int, timeout)
         })? as usize)
     }
 }

--- a/src/gpio/interrupt.rs
+++ b/src/gpio/interrupt.rs
@@ -38,10 +38,6 @@ struct Interrupt {
 
 impl Interrupt {
     fn new(fd: i32, pin: u8, trigger: Trigger) -> Result<Interrupt> {
-        let chip_info = ioctl::ChipInfo::new(fd)?;
-
-        assert_pin!(u32::from(pin), chip_info.lines);
-
         let event_request = ioctl::EventRequest::new(fd, pin, trigger)?;
 
         Ok(Interrupt {

--- a/src/gpio/ioctl.rs
+++ b/src/gpio/ioctl.rs
@@ -264,10 +264,10 @@ impl EventData {
                 event_fd,
                 &mut event_data as *mut EventData as *mut c_void,
                 size_of::<EventData>(),
-            ) as i32
+            )
         })?;
 
-        if bytes_read != size_of::<EventData>() as i32 {
+        if bytes_read != size_of::<EventData>() as isize {
             Ok(None)
         } else {
             Ok(Some(event_data))

--- a/src/gpio/ioctl.rs
+++ b/src/gpio/ioctl.rs
@@ -284,10 +284,10 @@ pub struct Event {
 impl Event {
     fn from_event_data(event_data: EventData) -> Event {
         Event {
-            trigger: if event_data.id == EVENT_TYPE_RISING_EDGE {
-                Trigger::RisingEdge
-            } else {
-                Trigger::FallingEdge
+            trigger: match event_data.id {
+                EVENT_TYPE_RISING_EDGE => Trigger::RisingEdge,
+                EVENT_TYPE_FALLING_EDGE => Trigger::FallingEdge,
+                _ => unreachable!(),
             },
             timestamp: Duration::from_nanos(event_data.timestamp),
         }

--- a/src/gpio/ioctl.rs
+++ b/src/gpio/ioctl.rs
@@ -323,10 +323,6 @@ pub fn find_driver() -> Result<File> {
 }
 
 pub fn get_level(cdev_fd: c_int, pin: u8) -> Result<Level> {
-    let chip_info = ChipInfo::new(cdev_fd)?;
-
-    assert_pin!(u32::from(pin), chip_info.lines);
-
     match HandleRequest::new(cdev_fd, &[pin])?.levels()?.values[0] {
         0 => Ok(Level::Low),
         1 => Ok(Level::High),

--- a/src/gpio/mem.rs
+++ b/src/gpio/mem.rs
@@ -192,7 +192,7 @@ impl GpioMem {
 
         let reg_value = self.read(offset);
 
-        unsafe { std::mem::transmute((reg_value & (1 << shift)) as u8) }
+        unsafe { std::mem::transmute((reg_value >> shift) as u8 & 0b1) }
     }
 
     pub fn mode(&self, pin: u8) -> Mode {

--- a/src/gpio/mem.rs
+++ b/src/gpio/mem.rs
@@ -140,14 +140,14 @@ impl GpioMem {
         debug_assert!(offset < GPIO_MEM_SIZE);
 
         loop {
-          if self.locks[offset].compare_and_swap(false, true, Ordering::Relaxed) == false {
+          if self.locks[offset].compare_and_swap(false, true, Ordering::SeqCst) == false {
             break;
           }
         }
 
         let res = unsafe { ptr::read_volatile(self.mem_ptr.add(offset)) };
 
-        self.locks[offset].store(false, Ordering::Relaxed);
+        self.locks[offset].store(false, Ordering::SeqCst);
 
         res
     }
@@ -156,7 +156,7 @@ impl GpioMem {
         debug_assert!(offset < GPIO_MEM_SIZE);
 
         loop {
-          if self.locks[offset].compare_and_swap(false, true, Ordering::Relaxed) == false {
+          if self.locks[offset].compare_and_swap(false, true, Ordering::SeqCst) == false {
             break;
           }
         }
@@ -165,7 +165,7 @@ impl GpioMem {
             ptr::write_volatile(self.mem_ptr.add(offset), value);
         }
 
-        self.locks[offset].store(false, Ordering::Relaxed);
+        self.locks[offset].store(false, Ordering::SeqCst);
     }
 }
 

--- a/src/gpio/mem.rs
+++ b/src/gpio/mem.rs
@@ -75,15 +75,11 @@ impl GpioMem {
         // /dev/gpiomem doesn't exist (< Raspbian Jessie), or /dev/gpiomem
         // doesn't have the appropriate permissions, or the current user is
         // not a member of the gpio group.
-        let gpiomem_file = match OpenOptions::new()
+        let gpiomem_file = OpenOptions::new()
             .read(true)
             .write(true)
             .custom_flags(libc::O_SYNC)
-            .open("/dev/gpiomem")
-        {
-            Ok(file) => file,
-            Err(e) => return Err(Error::Io(e)),
-        };
+            .open("/dev/gpiomem")?;
 
         // Memory-map /dev/gpiomem at offset 0
         let gpiomem_ptr = unsafe {
@@ -106,20 +102,13 @@ impl GpioMem {
 
     fn map_devmem(&self) -> Result<*mut u32> {
         // Identify which SoC we're using, so we know what offset to start at
-        let device_info = match DeviceInfo::new() {
-            Ok(s) => s,
-            Err(_) => return Err(Error::UnknownSoC),
-        };
+        let device_info = DeviceInfo::new().map_err(|_| Error::UnknownSoC)?;
 
-        let mem_file = match OpenOptions::new()
+        let mem_file = OpenOptions::new()
             .read(true)
             .write(true)
             .custom_flags(libc::O_SYNC)
-            .open("/dev/mem")
-        {
-            Ok(file) => file,
-            Err(e) => return Err(Error::Io(e)),
-        };
+            .open("/dev/mem")?;
 
         // Memory-map /dev/mem at the appropriate offset for our SoC
         let mem_ptr = unsafe {

--- a/src/gpio/pin.rs
+++ b/src/gpio/pin.rs
@@ -2,8 +2,9 @@ use std::fs::File;
 use std::os::unix::io::AsRawFd;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use std::thread::sleep;
 
-use crate::gpio::{Result, Mode, Level, Trigger, GPIO_OFFSET_GPLEV, GPIO_OFFSET_GPFSEL, GPIO_OFFSET_GPCLR, GPIO_OFFSET_GPSET, mem::GpioMem, interrupt::{AsyncInterrupt, EventLoop}};
+use crate::gpio::{Result, Mode, Level, Trigger, PullUpDown, GPIO_OFFSET_GPLEV, GPIO_OFFSET_GPFSEL, GPIO_OFFSET_GPPUDCLK, GPIO_OFFSET_GPPUD, GPIO_OFFSET_GPCLR, GPIO_OFFSET_GPSET, mem::GpioMem, interrupt::{AsyncInterrupt, EventLoop}};
 
 #[derive(Debug)]
 pub struct Pin {
@@ -49,6 +50,39 @@ impl Pin {
         let mode_value = ((reg_value >> ((self.pin % 10) * 3)) & 0b111) as u8;
 
         mode_value.into()
+    }
+
+    /// Configures the built-in GPIO pull-up/pull-down resistors.
+    pub fn set_pullupdown(&self, pud: PullUpDown) -> Result<()> {
+        let gpio_mem = &*self.gpio_mem.lock().unwrap();
+
+        // Set the control signal in GPPUD, while leaving the other 30
+        // bits unchanged.
+        let reg_value = gpio_mem.read(GPIO_OFFSET_GPPUD);
+        gpio_mem.write(
+            GPIO_OFFSET_GPPUD,
+            (reg_value & !0b11) | ((pud as u32) & 0b11),
+        );
+
+        // Set-up time for the control signal.
+        sleep(Duration::new(0, 20000)); // >= 20µs
+
+        // Select the first GPPUDCLK register for the first 32 pins, and
+        // the second register for the remaining pins.
+        let reg_addr: usize = GPIO_OFFSET_GPPUDCLK + (self.pin / 32) as usize;
+
+        // Clock the control signal into the selected pin.
+        gpio_mem.write(reg_addr, 1 << (self.pin % 32));
+
+        // Hold time for the control signal.
+        sleep(Duration::new(0, 20000)); // >= 20µs
+
+        // Remove the control signal and clock.
+        let reg_value = gpio_mem.read(GPIO_OFFSET_GPPUD);
+        gpio_mem.write(GPIO_OFFSET_GPPUD, reg_value & !0b11);
+        gpio_mem.write(reg_addr, 0 << (self.pin % 32));
+
+        Ok(())
     }
 }
 

--- a/src/gpio/pin.rs
+++ b/src/gpio/pin.rs
@@ -131,7 +131,7 @@ impl<'a> InputPin<'a> {
     ///
     /// [`set_interrupt`]: #method.set_interrupt
     pub fn poll_interrupt(&mut self, reset: bool, timeout: Option<Duration>) -> Result<Option<Level>> {
-        let opt = (*self.pin.event_loop.lock().unwrap()).poll(&[self.pin.pin], reset, timeout)?;
+        let opt = (*self.pin.event_loop.lock().unwrap()).poll(&[self], reset, timeout)?;
 
         if let Some(trigger) = opt {
             Ok(Some(trigger.1))

--- a/src/gpio/pin.rs
+++ b/src/gpio/pin.rs
@@ -90,7 +90,6 @@ impl Pin {
 pub struct InputPin<'a> {
     pin: &'a mut Pin,
     prev_mode: Option<Mode>,
-    sync_interrupt: Option<EventLoop>,
     async_interrupt: Option<AsyncInterrupt>,
 }
 
@@ -105,7 +104,7 @@ impl<'a> InputPin<'a> {
             Some(prev_mode)
         };
 
-        InputPin { pin, prev_mode, sync_interrupt: None, async_interrupt: None }
+        InputPin { pin, prev_mode, async_interrupt: None }
     }
 
     pub fn read(&self) -> Level {

--- a/src/gpio/pin.rs
+++ b/src/gpio/pin.rs
@@ -11,11 +11,11 @@ pub struct Pin {
     pin: u8,
     event_loop: Arc<Mutex<EventLoop>>,
     gpio_mem: Arc<GpioMem>,
-    gpio_cdev: Arc<Mutex<File>>,
+    gpio_cdev: Arc<File>,
 }
 
 impl Pin {
-    pub(crate) fn new(pin: u8, event_loop: Arc<Mutex<EventLoop>>, gpio_mem: Arc<GpioMem>, gpio_cdev: Arc<Mutex<File>>) -> Pin {
+    pub(crate) fn new(pin: u8, event_loop: Arc<Mutex<EventLoop>>, gpio_mem: Arc<GpioMem>, gpio_cdev: Arc<File>) -> Pin {
         Pin { pin, event_loop, gpio_mem, gpio_cdev }
     }
 
@@ -201,7 +201,7 @@ impl<'a> InputPin<'a> {
         self.clear_async_interrupt()?;
 
         self.async_interrupt = Some(AsyncInterrupt::new(
-            (*self.pin.gpio_cdev.lock().unwrap()).as_raw_fd(),
+            (*self.pin.gpio_cdev).as_raw_fd(),
             self.pin.pin,
             trigger,
             callback,

--- a/src/gpio/pin.rs
+++ b/src/gpio/pin.rs
@@ -39,9 +39,9 @@ impl Pin {
     pub fn mode(&self) -> Mode {
         let reg_addr: usize = GPIO_OFFSET_GPFSEL + (self.pin / 10) as usize;
         let reg_value = (*self.gpio_mem).read(reg_addr);
-        let mode_value = ((reg_value >> ((self.pin % 10) * 3)) & 0b111) as u8;
+        let mode_value = reg_value >> ((self.pin % 10) * 3);
 
-        mode_value.into()
+        unsafe { std::mem::transmute((mode_value as u8) & 0b111) }
     }
 
     /// Configures the built-in GPIO pull-up/pull-down resistors.

--- a/src/gpio/pin.rs
+++ b/src/gpio/pin.rs
@@ -11,7 +11,7 @@ pub const MAX: usize = 54;
 
 #[derive(Debug)]
 pub struct Pin {
-    pin: u8,
+    pub(crate) pin: u8,
     event_loop: Arc<Mutex<EventLoop>>,
     gpio_mem: Arc<GpioMem>,
     gpio_cdev: Arc<File>,
@@ -51,7 +51,7 @@ impl Pin {
 
 #[derive(Debug)]
 pub struct InputPin<'a> {
-    pin: &'a mut Pin,
+    pub(crate) pin: &'a mut Pin,
     prev_mode: Option<Mode>,
     async_interrupt: Option<AsyncInterrupt>,
     clear_on_drop: bool,

--- a/src/gpio/pin.rs
+++ b/src/gpio/pin.rs
@@ -305,6 +305,7 @@ impl<'a> OutputPin<'a> {
         OutputPin { pin, prev_mode, clear_on_drop: true }
     }
 
+    impl_input!();
     impl_output!();
 }
 

--- a/src/gpio/pin.rs
+++ b/src/gpio/pin.rs
@@ -32,15 +32,7 @@ impl Pin {
     }
 
     pub(crate) fn set_mode(&mut self, mode: Mode) {
-        let reg_addr: usize = GPIO_OFFSET_GPFSEL + (self.pin / 10) as usize;
-
-        let reg_value = (*self.gpio_mem).read(reg_addr);
-        (*self.gpio_mem).write(
-            reg_addr,
-            (reg_value & !(0b111 << ((self.pin % 10) * 3)))
-                | ((mode as u32 & 0b111) << ((self.pin % 10) * 3)),
-        );
-
+        (*self.gpio_mem).set_mode(self.pin, mode);
     }
 
     /// Returns the current GPIO pin mode.

--- a/src/gpio/pin.rs
+++ b/src/gpio/pin.rs
@@ -1,0 +1,135 @@
+use std::sync::{Arc, Mutex};
+
+use crate::gpio::{Mode, Level, GPIO_OFFSET_GPLEV, GPIO_OFFSET_GPFSEL, GPIO_OFFSET_GPCLR, GPIO_OFFSET_GPSET, mem::GpioMem};
+
+#[derive(Debug)]
+pub struct Pin {
+    pin: u8,
+    gpio_mem: Arc<Mutex<GpioMem>>,
+}
+
+impl Pin {
+    pub(crate) fn new(pin: u8, gpio_mem: Arc<Mutex<GpioMem>>) -> Pin {
+        Pin { pin, gpio_mem }
+    }
+
+    pub fn as_input(&mut self) -> InputPin {
+        InputPin::new(self)
+    }
+
+    pub fn as_output(&mut self) -> OutputPin {
+        OutputPin::new(self, Mode::Output)
+    }
+
+    pub fn as_output_with_mode(&mut self, mode: Mode) -> OutputPin {
+        OutputPin::new(self, mode)
+    }
+
+    pub(crate) fn set_mode(&mut self, mode: Mode) {
+        let reg_addr: usize = GPIO_OFFSET_GPFSEL + (self.pin / 10) as usize;
+
+        let reg_value = (*self.gpio_mem.lock().unwrap()).read(reg_addr);
+        (*self.gpio_mem.lock().unwrap()).write(
+            reg_addr,
+            (reg_value & !(0b111 << ((self.pin % 10) * 3)))
+                | ((mode as u32 & 0b111) << ((self.pin % 10) * 3)),
+        );
+
+    }
+
+    /// Returns the current GPIO pin mode.
+    pub fn mode(&self) -> Mode {
+        let reg_addr: usize = GPIO_OFFSET_GPFSEL + (self.pin / 10) as usize;
+        let reg_value = (*self.gpio_mem.lock().unwrap()).read(reg_addr);
+        let mode_value = ((reg_value >> ((self.pin % 10) * 3)) & 0b111) as u8;
+
+        mode_value.into()
+    }
+}
+
+#[derive(Debug)]
+pub struct InputPin<'a> {
+    pin: &'a mut Pin,
+    prev_mode: Option<Mode>,
+}
+
+impl<'a> InputPin<'a> {
+    pub(crate) fn new(pin: &'a mut Pin) -> InputPin<'a> {
+        let prev_mode = pin.mode();
+
+        let prev_mode = if prev_mode == Mode::Input {
+            None
+        } else {
+            pin.set_mode(Mode::Input);
+            Some(prev_mode)
+        };
+
+        InputPin { pin, prev_mode }
+    }
+
+    pub fn read(&self) -> Level {
+        let reg_addr: usize = GPIO_OFFSET_GPLEV + (self.pin.pin / 32) as usize;
+        let reg_value = (*self.pin.gpio_mem.lock().unwrap()).read(reg_addr);
+
+        if (reg_value & (1 << (self.pin.pin % 32))) > 0 {
+            Level::High
+        } else {
+            Level::Low
+        }
+    }
+}
+
+impl<'a> Drop for InputPin<'a> {
+    fn drop(&mut self) {
+        if let Some(prev_mode) = self.prev_mode {
+            self.pin.set_mode(prev_mode)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct OutputPin<'a> {
+    pin: &'a mut Pin,
+    mode: Mode,
+    prev_mode: Option<Mode>,
+}
+
+impl<'a> OutputPin<'a> {
+    pub(crate) fn new(pin: &'a mut Pin, mode: Mode) -> OutputPin<'a> {
+        let prev_mode = pin.mode();
+
+        let prev_mode = if prev_mode == mode {
+            None
+        } else {
+            pin.set_mode(mode);
+            Some(prev_mode)
+        };
+
+        OutputPin { pin, mode, prev_mode }
+    }
+
+    pub fn set_low(&mut self) {
+        self.write(Level::Low)
+    }
+
+    pub fn set_high(&mut self) {
+        self.write(Level::High)
+    }
+
+    pub fn write(&mut self, level: Level) {
+        let reg_addr: usize = match level {
+            Level::Low => GPIO_OFFSET_GPCLR + (self.pin.pin / 32) as usize,
+            Level::High => GPIO_OFFSET_GPSET + (self.pin.pin / 32) as usize,
+        };
+
+        (*self.pin.gpio_mem.lock().unwrap()).write(reg_addr, 1 << (self.pin.pin % 32));
+    }
+}
+
+impl<'a> Drop for OutputPin<'a> {
+  fn drop(&mut self) {
+    if let Some(prev_mode) = self.prev_mode {
+      self.pin.set_mode(prev_mode)
+    }
+  }
+}

--- a/src/system.rs
+++ b/src/system.rs
@@ -143,7 +143,7 @@ fn parse_proc_cpuinfo() -> Result<Model> {
         // Older revisions are 4 characters long, or 8 if they've been over-volted
         match &revision[revision.len() - 4..] {
             "0007" | "0008" | "0009" | "0015" => Model::RaspberryPiA,
-            "Beta" | "0002" | "0003" => Model::RaspberryPiBRev1,
+            "beta" | "0002" | "0003" => Model::RaspberryPiBRev1,
             "0004" | "0005" | "0006" | "000d" | "000e" | "000f" => Model::RaspberryPiBRev2,
             "0012" => Model::RaspberryPiAPlus,
             "0010" | "0013" => Model::RaspberryPiBPlus,


### PR DESCRIPTION
As mentioned in https://github.com/golemparts/rppal/pull/13. This changes `Gpio` to return a single `Pin`.

`Gpio::get_pin` returns a `Option<MutexGuard<Pin>>` so that every pin can only be used by one thread at a time.

Made `GpioMem` lock-free so that no `Mutex` is needed if multiple pins use it concurrently.

`Pin` can be used as an `InputPin` or an `OutputPin`. `InputPin` has `read` and all interrupt-related methods, `OutputPin` only has `set_low` and `set_high` and `write` methods. Both have `set_clear_on_drop`.

Example:

```rust
let gpio = Gpio::new()?;
let mut pin = *gpio.get_pin(8).unwrap();
let mut output_pin = pin.as_output();
output_pin.set_high();
```

Some things I'm not sure about:

- Can only inputs be `pull-up/pull-down`?
- What to do with `Gpio::poll_interrupts`?
