### PR TITLE
 Pwm: Add reset_on_drop flag.

### DIFF
--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -442,7 +442,7 @@ impl Drop for Pwm {
     fn drop(&mut self) {
         if self.reset_on_drop {
             let _ = sysfs::set_enabled(self.channel as u8, false);
+            let _ = sysfs::unexport(self.channel as u8);
         }
-        let _ = sysfs::unexport(self.channel as u8);
     }
 }


### PR DESCRIPTION
This adds a settable flag to Pwm acting similarly to Pin's flag of the same name, making it possible to enable a PWM channel and keep it enabled without keeping the Pwm instance around.