### PR TITLE
hal: Countdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ libc = "0.2.50"
 lazy_static = "1.3.0"
 nb = { version = "0.1.1", optional = true }
 embedded-hal = { version = "0.2.2", optional = true }
+bitrate = "0.1.1"
+
+[dependencies.void]
+default-features = false
+version = "1.0.2"
 
 [dev-dependencies]
 simple-signal = "1.1.1"

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -110,28 +110,42 @@ impl Timer {
     }
 }
 
-pub struct MicroSeconds(u64);
+pub struct Millisecond(pub u64);
+pub struct MicroSecond(pub u64);
+pub struct Second(pub u64);
 
-impl From<Hertz<u64>> for MicroSeconds {
+impl From<Hertz<u64>> for MicroSecond {
     fn from(item: Hertz<u64>) -> Self {
-        MicroSeconds(item.0 * 1_000_000)
+        MicroSecond(item.0 * 1_000_000)
     }
 }
 
-impl MicroSeconds {
+impl From<Millisecond> for MicroSecond {
+    fn from(item: Millisecond) -> Self {
+        MicroSecond(item.0 * 1_000)
+    }
+}
+
+impl From<Second> for MicroSecond {
+    fn from(item: Second) -> Self {
+        MicroSecond(item.0 * 1_000_000)
+    }
+}
+
+impl MicroSecond {
     fn as_u64(&self) -> u64 {
-        let &MicroSeconds(t) = self;
+        let &MicroSecond(t) = self;
         t
     }
 }
 
 impl CountDown for Timer {
-    type Time = MicroSeconds;
+    type Time = MicroSecond;
 
     /// Start the timer with a `timeout`
     fn start<T>(&mut self, timeout: T)
     where
-        T: Into<MicroSeconds>,
+        T: Into<MicroSecond>,
     {
         self.duration = Duration::from_micros(timeout.into().as_u64());
         self.now = Instant::now();


### PR DESCRIPTION
Closes #25 

My implementation in wiegand is working in milliseconds so I create MicroSeconds because I think thats about the resolution we should be at. Im not sure if we could tick slower reliably on the pi?

Also need to make a decision to use bitrate or something else. There doesnt seem to be a lot of movement on standardizing yet but most of the embedded hal stuff wants to live in Hertz land right now.

Im not sure how to put dependencies behind feature flags for void and bitrate

