### PR TITLE
Remove MSG_WAITING flag in software PWM implementation

### DIFF
--- a/src/gpio/soft_pwm.rs
+++ b/src/gpio/soft_pwm.rs
@@ -23,7 +23,6 @@
 #![allow(dead_code)]
 
 use std::ptr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
 use std::thread;

--- a/src/gpio/soft_pwm.rs
+++ b/src/gpio/soft_pwm.rs
@@ -42,8 +42,6 @@ const BUSYWAIT_MAX: i64 = 200_000;
 // Subtract from the remaining busy wait time to account for get_time_ns() overhead
 const BUSYWAIT_REMAINDER: i64 = 100;
 
-static mut MSG_WAITING: AtomicBool = AtomicBool::new(false);
-
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 enum Msg {
     Reconfigure(Duration, Duration),
@@ -129,26 +127,23 @@ impl SoftPwm {
                 // PWM inactive
                 gpio_state.gpio_mem.set_low(pin);
 
-                // This is slightly faster than directly checking try_recv()
-                if unsafe { MSG_WAITING.compare_and_swap(true, false, Ordering::AcqRel) } {
-                    while let Ok(msg) = receiver.try_recv() {
-                        match msg {
-                            Msg::Reconfigure(period, pulse_width) => {
-                                // Reconfigure period and pulse width
-                                pulse_width_ns = (pulse_width.as_secs() as i64 * 1_000_000_000)
-                                    + pulse_width.subsec_nanos() as i64;
+                while let Ok(msg) = receiver.try_recv() {
+                    match msg {
+                        Msg::Reconfigure(period, pulse_width) => {
+                            // Reconfigure period and pulse width
+                            pulse_width_ns = (pulse_width.as_secs() as i64 * 1_000_000_000)
+                                + pulse_width.subsec_nanos() as i64;
 
-                                period_ns = (period.as_secs() as i64 * 1_000_000_000)
-                                    + period.subsec_nanos() as i64;
+                            period_ns = (period.as_secs() as i64 * 1_000_000_000)
+                                + period.subsec_nanos() as i64;
 
-                                if pulse_width_ns > period_ns {
-                                    pulse_width_ns = period_ns;
-                                }
+                            if pulse_width_ns > period_ns {
+                                pulse_width_ns = period_ns;
                             }
-                            Msg::Stop => {
-                                // The main thread asked us to stop
-                                return Ok(());
-                            }
+                        }
+                        Msg::Stop => {
+                            // The main thread asked us to stop
+                            return Ok(());
                         }
                     }
                 }
@@ -181,17 +176,10 @@ impl SoftPwm {
 
     pub(crate) fn reconfigure(&mut self, period: Duration, pulse_width: Duration) {
         let _ = self.sender.send(Msg::Reconfigure(period, pulse_width));
-        unsafe {
-            MSG_WAITING.store(true, Ordering::Release);
-        }
     }
 
     pub(crate) fn stop(&mut self) -> Result<()> {
         let _ = self.sender.send(Msg::Stop);
-        unsafe {
-            MSG_WAITING.store(true, Ordering::Release);
-        }
-
         if let Some(pwm_thread) = self.pwm_thread.take() {
             match pwm_thread.join() {
                 Ok(r) => return r,


### PR DESCRIPTION
I have absolutely no idea why this occurs, but storing/loading `MSG_WAITING` as a means of saying "there's a message here" caused message deliveries to be missed until the next delivery empirically. This led to some nasty bugs in my project (even after switching to `Ordering::SeqCst`). Removing this flag and just using `try_recv` alone has resolved these issues.