### PR TITLE
Update to fixed cargo build warning for unnecessary parentheses in io…

### DIFF
--- a/src/gpio/ioctl.rs
+++ b/src/gpio/ioctl.rs
@@ -20,6 +20,7 @@
 
 #![allow(dead_code)]
 
+use crate::gpio::{Error, Level, Result, Trigger};
 use libc::{self, c_int, c_ulong, c_void, ENOENT};
 use std::ffi::CString;
 use std::fmt;
@@ -29,8 +30,6 @@ use std::mem;
 use std::os::unix::io::AsRawFd;
 use std::time::Duration;
 
-use crate::gpio::{Error, Level, Result, Trigger};
-
 #[cfg(target_env = "gnu")]
 type IoctlLong = libc::c_ulong;
 #[cfg(target_env = "musl")]
@@ -39,24 +38,20 @@ type IoctlLong = c_int;
 const PATH_GPIOCHIP: &str = "/dev/gpiochip";
 const CONSUMER_LABEL: &str = "RPPAL";
 const DRIVER_NAME: &[u8] = b"pinctrl-bcm2835\0";
-
 const NRBITS: u8 = 8;
 const TYPEBITS: u8 = 8;
 const SIZEBITS: u8 = 14;
 const DIRBITS: u8 = 2;
-
 const NRSHIFT: u8 = 0;
-const TYPESHIFT: u8 = (NRSHIFT + NRBITS);
-const SIZESHIFT: u8 = (TYPESHIFT + TYPEBITS);
-const DIRSHIFT: u8 = (SIZESHIFT + SIZEBITS);
-
+const TYPESHIFT: u8 = NRSHIFT + NRBITS;
+const SIZESHIFT: u8 = TYPESHIFT + TYPEBITS;
+const DIRSHIFT: u8 = SIZESHIFT + SIZEBITS;
 const NR_GET_CHIP_INFO: IoctlLong = 0x01 << NRSHIFT;
 const NR_GET_LINE_INFO: IoctlLong = 0x02 << NRSHIFT;
 const NR_GET_LINE_HANDLE: IoctlLong = 0x03 << NRSHIFT;
 const NR_GET_LINE_EVENT: IoctlLong = 0x04 << NRSHIFT;
 const NR_GET_LINE_VALUES: IoctlLong = 0x08 << NRSHIFT;
 const NR_SET_LINE_VALUES: IoctlLong = 0x09 << NRSHIFT;
-
 const TYPE_GPIO: IoctlLong = (0xB4 as IoctlLong) << TYPESHIFT;
 
 const SIZE_CHIP_INFO: IoctlLong = (mem::size_of::<ChipInfo>() as IoctlLong) << SIZESHIFT;

--- a/src/spi/ioctl.rs
+++ b/src/spi/ioctl.rs
@@ -20,68 +20,57 @@
 
 #![allow(dead_code)]
 
+use super::segment::Segment;
 use libc::{self, c_int, ioctl};
 use std::io;
 use std::mem;
 use std::result;
 
-use super::segment::Segment;
-
 #[cfg(target_env = "gnu")]
 type IoctlLong = libc::c_ulong;
 #[cfg(target_env = "musl")]
 type IoctlLong = c_int;
-
 pub type Result<T> = result::Result<T, io::Error>;
 
 const NRBITS: u8 = 8;
 const TYPEBITS: u8 = 8;
 const SIZEBITS: u8 = 14;
 const DIRBITS: u8 = 2;
-
 const NRSHIFT: u8 = 0;
-const TYPESHIFT: u8 = (NRSHIFT + NRBITS);
-const SIZESHIFT: u8 = (TYPESHIFT + TYPEBITS);
-const DIRSHIFT: u8 = (SIZESHIFT + SIZEBITS);
-
+const TYPESHIFT: u8 = NRSHIFT + NRBITS;
+const SIZESHIFT: u8 = TYPESHIFT + TYPEBITS;
+const DIRSHIFT: u8 = SIZESHIFT + SIZEBITS;
 const NR_MESSAGE: IoctlLong = 0 << NRSHIFT;
 const NR_MODE: IoctlLong = 1 << NRSHIFT;
 const NR_LSB_FIRST: IoctlLong = 2 << NRSHIFT;
 const NR_BITS_PER_WORD: IoctlLong = 3 << NRSHIFT;
 const NR_MAX_SPEED_HZ: IoctlLong = 4 << NRSHIFT;
 const NR_MODE32: IoctlLong = 5 << NRSHIFT;
-
 const TYPE_SPI: IoctlLong = (b'k' as IoctlLong) << TYPESHIFT;
-
 const SIZE_U8: IoctlLong = (mem::size_of::<u8>() as IoctlLong) << SIZESHIFT;
 const SIZE_U32: IoctlLong = (mem::size_of::<u32>() as IoctlLong) << SIZESHIFT;
-
 const DIR_NONE: IoctlLong = 0;
 const DIR_WRITE: IoctlLong = 1 << DIRSHIFT;
 const DIR_READ: IoctlLong = 2 << DIRSHIFT;
-
-const REQ_RD_MODE: IoctlLong = (DIR_READ | TYPE_SPI | NR_MODE | SIZE_U8);
-const REQ_RD_LSB_FIRST: IoctlLong = (DIR_READ | TYPE_SPI | NR_LSB_FIRST | SIZE_U8);
-const REQ_RD_BITS_PER_WORD: IoctlLong = (DIR_READ | TYPE_SPI | NR_BITS_PER_WORD | SIZE_U8);
-const REQ_RD_MAX_SPEED_HZ: IoctlLong = (DIR_READ | TYPE_SPI | NR_MAX_SPEED_HZ | SIZE_U32);
-const REQ_RD_MODE_32: IoctlLong = (DIR_READ | TYPE_SPI | NR_MODE32 | SIZE_U32);
-
-const REQ_WR_MESSAGE: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_MESSAGE);
-const REQ_WR_MODE: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_MODE | SIZE_U8);
-const REQ_WR_LSB_FIRST: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_LSB_FIRST | SIZE_U8);
-const REQ_WR_BITS_PER_WORD: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_BITS_PER_WORD | SIZE_U8);
-const REQ_WR_MAX_SPEED_HZ: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_MAX_SPEED_HZ | SIZE_U32);
-const REQ_WR_MODE_32: IoctlLong = (DIR_WRITE | TYPE_SPI | NR_MODE32 | SIZE_U32);
-
+const REQ_RD_MODE: IoctlLong = DIR_READ | TYPE_SPI | NR_MODE | SIZE_U8;
+const REQ_RD_LSB_FIRST: IoctlLong = DIR_READ | TYPE_SPI | NR_LSB_FIRST | SIZE_U8;
+const REQ_RD_BITS_PER_WORD: IoctlLong = DIR_READ | TYPE_SPI | NR_BITS_PER_WORD | SIZE_U8;
+const REQ_RD_MAX_SPEED_HZ: IoctlLong = DIR_READ | TYPE_SPI | NR_MAX_SPEED_HZ | SIZE_U32;
+const REQ_RD_MODE_32: IoctlLong = DIR_READ | TYPE_SPI | NR_MODE32 | SIZE_U32;
+const REQ_WR_MESSAGE: IoctlLong = DIR_WRITE | TYPE_SPI | NR_MESSAGE;
+const REQ_WR_MODE: IoctlLong = DIR_WRITE | TYPE_SPI | NR_MODE | SIZE_U8;
+const REQ_WR_LSB_FIRST: IoctlLong = DIR_WRITE | TYPE_SPI | NR_LSB_FIRST | SIZE_U8;
+const REQ_WR_BITS_PER_WORD: IoctlLong = DIR_WRITE | TYPE_SPI | NR_BITS_PER_WORD | SIZE_U8;
+const REQ_WR_MAX_SPEED_HZ: IoctlLong = DIR_WRITE | TYPE_SPI | NR_MAX_SPEED_HZ | SIZE_U32;
+const REQ_WR_MODE_32: IoctlLong = DIR_WRITE | TYPE_SPI | NR_MODE32 | SIZE_U32;
 pub const MODE_CPHA: u8 = 0x01;
 pub const MODE_CPOL: u8 = 0x02;
-
 pub const MODE_0: u8 = 0;
 pub const MODE_1: u8 = MODE_CPHA;
 pub const MODE_2: u8 = MODE_CPOL;
 pub const MODE_3: u8 = MODE_CPOL | MODE_CPHA;
-
-pub const MODE_CS_HIGH: u8 = 0x04; // Set SS to active high
+pub const MODE_CS_HIGH: u8 = 0x04;
+// Set SS to active high
 pub const MODE_LSB_FIRST: u8 = 0x08; // Set bit order to LSB first
 pub const MODE_3WIRE: u8 = 0x10; // Set bidirectional mode
 pub const MODE_LOOP: u8 = 0x20; // Set loopback mode


### PR DESCRIPTION
Just getting rid of the 14 or so cargo warnings in these files on build. Also a few Rustfmt changes in there as well.