### PR TITLE
Add chunking support for SPI reads and writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * **I2c**: Accept slave addresses below 0x08 (contributed by @Majkl578).
 * **I2c**: Add documentation for I2C3, I2C4, I2C5 and I2C6.
 * **Spi**: (Breaking change) Add support for SPI3, SPI4, SPI5 and SPI6.
+* **Spi**: Automatically chunk transmissions to keep them within the maximum buffer size.
 
 ## 0.11.3 (June 24, 2019)
 


### PR DESCRIPTION
Closes #61.

Linux limits the maximum SPI read and write length based on an internal buffer. If any individual read or write exceeds the buffer length, EMSGSIZE is returned. This commit adds code to optionally check for that buffer and chunk reads and writes across multiple calls to ensure that the buffer is never exceeded.

Submitted as a draft PR to gauge interest. Todos would be:

- [ ] Either figure out a way to support `Segment` chunking or explicitly document that it does not apply to `Segment`s
- [ ] Apply the `Segment` fix to `Spi::transfer`
- [ ] Add references to this functionality in the module docs