### PR TITLE
Give better error message when PWM is enabled without period

### DIFF
--- a/src/pwm/sysfs.rs
+++ b/src/pwm/sysfs.rs
@@ -248,7 +248,17 @@ pub fn enabled(channel: u8) -> Result<bool> {
 
 pub fn set_enabled(channel: u8, enabled: bool) -> Result<()> {
     File::create(format!("/sys/class/pwm/pwmchip0/pwm{}/enable", channel))?
-        .write_fmt(format_args!("{}", enabled as u8))?;
+        .write_fmt(format_args!("{}", enabled as u8))
+        .map_err(|e| {
+            if e.kind() == io::ErrorKind::InvalidInput {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Make sure you have set either a period or frequency before enabling PWM",
+                )
+            } else {
+                e
+            }
+        })?;
 
     Ok(())
 }


### PR DESCRIPTION
The first time I tried to use `rppal` with PWM I did something like:

```rust
    let mut my_pwm = rppal::pwm::Pwm::new(Channel::Pwm0).unwrap();
    my_pwm.set_reset_on_drop(false);
    my_pwm.enable()?;
```

Which kept panic-ing with errors like
> thread 'main' panicked at 'Can't setup PWM: I/O error: Invalid argument (os error 22)', src/main.rs:19:26

Specifically at 
> openat(AT_FDCWD, "/sys/class/pwm/pwmchip0/pwm0/enable", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 6
write(6, "0", 1)                        = -1 EINVAL (Invalid argument)
close(6)                                = 0
openat(AT_FDCWD, "/sys/class/pwm/pwmchip0/pwm0/enable", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 6
write(6, "1", 1)                        = -1 EINVAL (Invalid argument)

It took some head scratching, but I finally guessed that enabling was failing due to an improperly set period. And sure enough, manual inspection `cat /sys/class/pwm/pwmchip0/pwm0/period` giving`0` led me to use the `Pwm::with_frequency` API with success.

This PR makes the error message much more explanatory: 
> thread 'main' panicked at 'Can't setup PWM: I/O error: Make sure you have set either a period or frequency before enabling PWM', src/main.rs:19:26
