### PR TITLE
Add ioctl support for Rpi 4 v1.4 B

### DIFF
--- a/src/gpio/ioctl.rs
+++ b/src/gpio/ioctl.rs
@@ -38,6 +38,7 @@ type IoctlLong = c_int;
 const PATH_GPIOCHIP: &str = "/dev/gpiochip";
 const CONSUMER_LABEL: &str = "RPPAL";
 const DRIVER_NAME: &[u8] = b"pinctrl-bcm2835\0";
+const DRIVER_NAME_PI4: &[u8] = b"pinctrl-bcm2711\0";
 const NRBITS: u8 = 8;
 const TYPEBITS: u8 = 8;
 const SIZEBITS: u8 = 14;
@@ -429,7 +430,8 @@ pub fn find_gpiochip() -> Result<File> {
         };
 
         let chip_info = ChipInfo::new(gpiochip.as_raw_fd())?;
-        if chip_info.label[0..DRIVER_NAME.len()] == DRIVER_NAME[..] {
+        if chip_info.label[0..DRIVER_NAME.len()] == DRIVER_NAME[..] 
+            || chip_info.label[0..DRIVER_NAME_PI4.len()] == DRIVER_NAME_PI4[..] {
             return Ok(gpiochip);
         }
     }


### PR DESCRIPTION
The GPIO controller driver are associated with BCM2711 DTB, Added support for this device driver type with GPIO initiation