### PR TITLE
Deduplicate code.

### DIFF
--- a/src/gpio/interrupt.rs
+++ b/src/gpio/interrupt.rs
@@ -173,12 +173,7 @@ impl EventLoop {
                 let trigger_status = &mut self.trigger_status[pin];
 
                 if let Some(ref mut interrupt) = trigger_status.interrupt {
-                    trigger_status.level = match interrupt.event()?.trigger {
-                        Trigger::RisingEdge => Level::High,
-                        Trigger::FallingEdge => Level::Low,
-                        _ => unsafe { std::hint::unreachable_unchecked() },
-                    };
-
+                    trigger_status.level = interrupt.event()?.level();
                     trigger_status.triggered = true;
                 };
             }
@@ -278,11 +273,7 @@ impl AsyncInterrupt {
                         if fd == rx {
                             return Ok(()); // The main thread asked us to stop
                         } else if fd == interrupt.fd() {
-                            let level = match interrupt.event()?.trigger {
-                                Trigger::RisingEdge => Level::High,
-                                _ => Level::Low,
-                            };
-
+                            let level = interrupt.event()?.level();
                             callback(level);
                         }
                     }

--- a/src/gpio/ioctl.rs
+++ b/src/gpio/ioctl.rs
@@ -392,8 +392,8 @@ impl EventData {
 
 #[derive(Debug, Copy, Clone)]
 pub struct Event {
-    pub trigger: Trigger,
-    pub timestamp: Duration,
+    trigger: Trigger,
+    timestamp: Duration,
 }
 
 impl Event {
@@ -405,6 +405,21 @@ impl Event {
                 _ => unreachable!(),
             },
             timestamp: Duration::from_nanos(event_data.timestamp),
+        }
+    }
+
+    pub fn trigger(&self) -> Trigger {
+      self.trigger
+    }
+
+    pub fn level(&self) -> Level {
+        match self.trigger {
+            Trigger::RisingEdge => Level::High,
+            Trigger::FallingEdge => Level::Low,
+            _ => {
+                // SAFETY: `Event` can only be constructed with either `RisingEdge` or `FallingEdge`.
+                unsafe { std::hint::unreachable_unchecked() }
+            },
         }
     }
 }


### PR DESCRIPTION
Add `level` method to `Event` to reduce code duplication.