### PR TITLE
Update `embedded-hal` to 1.0.0-alpha.7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * (Breaking change) Transition to Rust 2021, requiring rustc v1.56.0 or newer to compile the library.
 * **Gpio**: Implement `unproven` `embedded-hal` trait `digital::v2::IoPin<IoPin, IoPin>` for `IoPin` (contributed by @rumatoest).
+* Update `embedded-hal` to v1.0.0-alpha.7 (contributed by @reitermarkus).
 
 ## 0.13.1 (October 28, 2021)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["raspberry", "pi", "embedded-hal", "embedded-hal-impl", "hal"]
 libc = "0.2"
 nb = { version = "0.1.1", optional = true }
 embedded-hal-0 = { version = "0.2.6", optional = true, package = "embedded-hal" }
-embedded-hal = { version = "=1.0.0-alpha.5", optional = true }
+embedded-hal = { version = "=1.0.0-alpha.7", optional = true }
 void = { version = "1.0.2", optional = true }
 spin_sleep = { version = "1.0.0", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 RPPAL provides access to the Raspberry Pi's GPIO, I2C, PWM, SPI and UART peripherals through a user-friendly interface. In addition to peripheral access, RPPAL also offers support for USB to serial adapters.
 
-The library can be used in conjunction with a variety of platform-agnostic drivers through its `embedded-hal` trait implementations. Both `embedded-hal` v0.2.6 and v1.0.0-alpha.5 are supported.
+The library can be used in conjunction with a variety of platform-agnostic drivers through its `embedded-hal` trait implementations. Both `embedded-hal` v0.2.6 and v1.0.0-alpha.7 are supported.
 
 RPPAL requires Raspberry Pi OS or any similar, recent, Linux distribution. Both `gnu` and `musl` libc targets are supported. RPPAL is compatible with the Raspberry Pi A, A+, B, B+, 2B, 3A+, 3B, 3B+, 4B, CM, CM 3, CM 3+, CM 4, 400, Zero, Zero W and Zero 2 W. Backwards compatibility for minor revisions isn't guaranteed until v1.0.0.
 

--- a/src/gpio/hal.rs
+++ b/src/gpio/hal.rs
@@ -19,20 +19,24 @@
 // DEALINGS IN THE SOFTWARE.
 
 use core::convert::Infallible;
-use std::time::Duration;
 
-use embedded_hal::digital::blocking::{
-    InputPin as InputPinHal, OutputPin as OutputPinHal, StatefulOutputPin as StatefulOutputPinHal,
-    ToggleableOutputPin as ToggleableOutputPinHal,
+use embedded_hal::digital::{
+  ErrorType,
+  blocking::{
+      InputPin as InputPinHal, OutputPin as OutputPinHal, StatefulOutputPin as StatefulOutputPinHal,
+      ToggleableOutputPin as ToggleableOutputPinHal,
+  },
 };
-use embedded_hal::pwm::blocking::{Pwm, PwmPin};
 
-use super::{Error, InputPin, IoPin, Level, OutputPin, Pin};
+use super::{InputPin, IoPin, Level, OutputPin, Pin};
 
-/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl InputPinHal for Pin {
+/// `ErrorType` trait implementation for `embedded-hal` v1.0.0-alpha.7.
+impl ErrorType for Pin {
     type Error = Infallible;
+}
 
+/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.7.
+impl InputPinHal for Pin {
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(Self::read(self) == Level::High)
     }
@@ -42,10 +46,13 @@ impl InputPinHal for Pin {
     }
 }
 
-/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
+/// `ErrorType` trait implementation for `embedded-hal` v1.0.0-alpha.7.
+impl ErrorType for InputPin {
+    type Error = Infallible;
+}
+
+/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.7.
 impl InputPinHal for InputPin {
-    type Error = Infallible;
-
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(Self::is_high(self))
     }
@@ -55,10 +62,13 @@ impl InputPinHal for InputPin {
     }
 }
 
-/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
+/// `ErrorType` trait implementation for `embedded-hal` v1.0.0-alpha.7.
+impl ErrorType for IoPin {
+    type Error = Infallible;
+}
+
+/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.7.
 impl InputPinHal for IoPin {
-    type Error = Infallible;
-
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(Self::is_high(self))
     }
@@ -68,10 +78,13 @@ impl InputPinHal for IoPin {
     }
 }
 
-/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl InputPinHal for OutputPin {
+/// `ErrorType` trait implementation for `embedded-hal` v1.0.0-alpha.7.
+impl ErrorType for OutputPin {
     type Error = Infallible;
+}
 
+/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.7.
+impl InputPinHal for OutputPin {
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(Self::is_set_high(self))
     }
@@ -81,10 +94,8 @@ impl InputPinHal for OutputPin {
     }
 }
 
-/// `OutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
+/// `OutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.7.
 impl OutputPinHal for OutputPin {
-    type Error = Infallible;
-
     fn set_low(&mut self) -> Result<(), Self::Error> {
         OutputPin::set_low(self);
 
@@ -111,7 +122,7 @@ impl embedded_hal_0::digital::v2::OutputPin for OutputPin {
     }
 }
 
-/// `StatefulOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
+/// `StatefulOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.7.
 impl StatefulOutputPinHal for OutputPin {
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         Ok(OutputPin::is_set_high(self))
@@ -122,10 +133,8 @@ impl StatefulOutputPinHal for OutputPin {
     }
 }
 
-/// `ToggleableOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
+/// `ToggleableOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.7.
 impl ToggleableOutputPinHal for OutputPin {
-    type Error = Infallible;
-
     fn toggle(&mut self) -> Result<(), Self::Error> {
         OutputPin::toggle(self);
 
@@ -133,10 +142,8 @@ impl ToggleableOutputPinHal for OutputPin {
     }
 }
 
-/// `OutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
+/// `OutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.7.
 impl OutputPinHal for IoPin {
-    type Error = Infallible;
-
     fn set_low(&mut self) -> Result<(), Self::Error> {
         IoPin::set_low(self);
 
@@ -163,7 +170,7 @@ impl embedded_hal_0::digital::v2::OutputPin for IoPin {
     }
 }
 
-/// `StatefulOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
+/// `StatefulOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.7.
 impl StatefulOutputPinHal for IoPin {
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         Ok(IoPin::is_high(self))
@@ -174,110 +181,10 @@ impl StatefulOutputPinHal for IoPin {
     }
 }
 
-/// `ToggleableOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
+/// `ToggleableOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.7.
 impl ToggleableOutputPinHal for IoPin {
-    type Error = Infallible;
-
     fn toggle(&mut self) -> Result<(), Self::Error> {
         IoPin::toggle(self);
-
-        Ok(())
-    }
-}
-
-const NANOS_PER_SEC: f64 = 1_000_000_000.0;
-
-/// `Pwm` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl embedded_hal::pwm::blocking::Pwm for OutputPin {
-    type Duty = f64;
-    type Channel = ();
-    type Time = Duration;
-    type Error = Error;
-
-    /// Disables a PWM `channel`.
-    fn disable(&mut self, _channel: &Self::Channel) -> Result<(), Self::Error> {
-        self.clear_pwm()
-    }
-
-    /// Enables a PWM `channel`.
-    fn enable(&mut self, _channel: &Self::Channel) -> Result<(), Self::Error> {
-        self.set_pwm_frequency(self.frequency, self.duty_cycle)
-    }
-
-    /// Returns the current PWM period.
-    fn get_period(&self) -> Result<Self::Time, Self::Error> {
-        Ok(Duration::from_nanos(if self.frequency == 0.0 {
-            0
-        } else {
-            ((1.0 / self.frequency) * NANOS_PER_SEC) as u64
-        }))
-    }
-
-    /// Returns the current duty cycle.
-    fn get_duty(&self, _channel: &Self::Channel) -> Result<Self::Duty, Self::Error> {
-        Ok(self.duty_cycle)
-    }
-
-    /// Returns the maximum duty cycle value.
-    fn get_max_duty(&self) -> Result<Self::Duty, Self::Error> {
-        Ok(1.0)
-    }
-
-    /// Sets a new duty cycle.
-    fn set_duty(&mut self, _channel: &Self::Channel, duty: Self::Duty) -> Result<(), Self::Error> {
-        self.duty_cycle = duty.max(0.0).min(1.0);
-
-        if self.soft_pwm.is_some() {
-            self.set_pwm_frequency(self.frequency, self.duty_cycle)?;
-        }
-
-        Ok(())
-    }
-
-    /// Sets a new PWM period.
-    fn set_period<P>(&mut self, period: P) -> Result<(), Self::Error>
-    where
-        P: Into<Self::Time>,
-    {
-        let period = period.into();
-        self.frequency =
-            1.0 / (period.as_secs() as f64 + (f64::from(period.subsec_nanos()) / NANOS_PER_SEC));
-
-        if self.soft_pwm.is_some() {
-            self.set_pwm_frequency(self.frequency, self.duty_cycle)?;
-        }
-
-        Ok(())
-    }
-}
-
-/// `PwmPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl PwmPin for OutputPin {
-    type Duty = f64;
-    type Error = Error;
-
-    fn disable(&mut self) -> Result<(), Self::Error> {
-        self.clear_pwm()
-    }
-
-    fn enable(&mut self) -> Result<(), Self::Error> {
-        self.set_pwm_frequency(self.frequency, self.duty_cycle)
-    }
-
-    fn get_duty(&self) -> Result<Self::Duty, Self::Error> {
-        Ok(self.duty_cycle)
-    }
-
-    fn get_max_duty(&self) -> Result<Self::Duty, Self::Error> {
-        Ok(1.0)
-    }
-
-    fn set_duty(&mut self, duty: Self::Duty) -> Result<(), Self::Error> {
-        self.duty_cycle = duty.max(0.0).min(1.0);
-
-        if self.soft_pwm.is_some() {
-            self.set_pwm_frequency(self.frequency, self.duty_cycle)?;
-        }
 
         Ok(())
     }
@@ -288,119 +195,27 @@ impl embedded_hal_0::PwmPin for OutputPin {
     type Duty = f64;
 
     fn disable(&mut self) {
-        let _ = PwmPin::disable(self);
+        let _ = self.clear_pwm();
     }
 
     fn enable(&mut self) {
-        let _ = PwmPin::enable(self);
+        let _ = self.set_pwm_frequency(self.frequency, self.duty_cycle);
     }
 
     fn get_duty(&self) -> Self::Duty {
-        PwmPin::get_duty(self).unwrap_or_default()
+        self.duty_cycle
     }
 
     fn get_max_duty(&self) -> Self::Duty {
-        PwmPin::get_max_duty(self).unwrap_or(1.0)
+        1.0
     }
 
     fn set_duty(&mut self, duty: Self::Duty) {
-        let _ = PwmPin::set_duty(self, duty);
-    }
-}
-
-/// `Pwm` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl Pwm for IoPin {
-    type Duty = f64;
-    type Channel = ();
-    type Time = Duration;
-    type Error = Error;
-
-    /// Disables a PWM `channel`.
-    fn disable(&mut self, _channel: &Self::Channel) -> Result<(), Self::Error> {
-        self.clear_pwm()
-    }
-
-    /// Enables a PWM `channel`.
-    fn enable(&mut self, _channel: &Self::Channel) -> Result<(), Self::Error> {
-        self.set_pwm_frequency(self.frequency, self.duty_cycle)
-    }
-
-    /// Returns the current PWM period.
-    fn get_period(&self) -> Result<Self::Time, Self::Error> {
-        Ok(Duration::from_nanos(if self.frequency == 0.0 {
-            0
-        } else {
-            ((1.0 / self.frequency) * NANOS_PER_SEC) as u64
-        }))
-    }
-
-    /// Returns the current duty cycle.
-    fn get_duty(&self, _channel: &Self::Channel) -> Result<Self::Duty, Self::Error> {
-        Ok(self.duty_cycle)
-    }
-
-    /// Returns the maximum duty cycle value.
-    fn get_max_duty(&self) -> Result<Self::Duty, Self::Error> {
-        Ok(1.0)
-    }
-
-    /// Sets a new duty cycle.
-    fn set_duty(&mut self, _channel: &Self::Channel, duty: Self::Duty) -> Result<(), Self::Error> {
         self.duty_cycle = duty.max(0.0).min(1.0);
 
         if self.soft_pwm.is_some() {
-            self.set_pwm_frequency(self.frequency, self.duty_cycle)?;
+            let _ = self.set_pwm_frequency(self.frequency, self.duty_cycle);
         }
-
-        Ok(())
-    }
-
-    /// Sets a new PWM period.
-    fn set_period<P>(&mut self, period: P) -> Result<(), Self::Error>
-    where
-        P: Into<Self::Time>,
-    {
-        let period = period.into();
-        self.frequency =
-            1.0 / (period.as_secs() as f64 + (f64::from(period.subsec_nanos()) / NANOS_PER_SEC));
-
-        if self.soft_pwm.is_some() {
-            self.set_pwm_frequency(self.frequency, self.duty_cycle)?;
-        }
-
-        Ok(())
-    }
-}
-
-/// `PwmPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl PwmPin for IoPin {
-    type Duty = f64;
-    type Error = Error;
-
-    fn disable(&mut self) -> Result<(), Self::Error> {
-        self.clear_pwm()
-    }
-
-    fn enable(&mut self) -> Result<(), Self::Error> {
-        self.set_pwm_frequency(self.frequency, self.duty_cycle)
-    }
-
-    fn get_duty(&self) -> Result<Self::Duty, Self::Error> {
-        Ok(self.duty_cycle)
-    }
-
-    fn get_max_duty(&self) -> Result<Self::Duty, Self::Error> {
-        Ok(1.0)
-    }
-
-    fn set_duty(&mut self, duty: Self::Duty) -> Result<(), Self::Error> {
-        self.duty_cycle = duty.max(0.0).min(1.0);
-
-        if self.soft_pwm.is_some() {
-            self.set_pwm_frequency(self.frequency, self.duty_cycle)?;
-        }
-
-        Ok(())
     }
 }
 
@@ -409,22 +224,26 @@ impl embedded_hal_0::PwmPin for IoPin {
     type Duty = f64;
 
     fn disable(&mut self) {
-        let _ = PwmPin::disable(self);
+        let _ = self.clear_pwm();
     }
 
     fn enable(&mut self) {
-        let _ = PwmPin::enable(self);
+        let _ = self.set_pwm_frequency(self.frequency, self.duty_cycle);
     }
 
     fn get_duty(&self) -> Self::Duty {
-        PwmPin::get_duty(self).unwrap_or_default()
+        self.duty_cycle
     }
 
     fn get_max_duty(&self) -> Self::Duty {
-        PwmPin::get_max_duty(self).unwrap_or(1.0)
+        1.0
     }
 
     fn set_duty(&mut self, duty: Self::Duty) {
-        let _ = PwmPin::set_duty(self, duty);
+        self.duty_cycle = duty.max(0.0).min(1.0);
+
+        if self.soft_pwm.is_some() {
+            let _ = self.set_pwm_frequency(self.frequency, self.duty_cycle);
+        }
     }
 }

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -29,8 +29,7 @@
 use core::convert::Infallible;
 use std::time::{Duration, Instant};
 
-use embedded_hal::delay::blocking::{DelayMs, DelayUs};
-use embedded_hal::timer::nb::CountDown;
+use embedded_hal::delay::blocking::{DelayUs};
 use spin_sleep::sleep;
 use void::Void;
 
@@ -38,7 +37,7 @@ use void::Void;
 #[derive(Debug, Default)]
 pub struct Delay;
 
-/// `Delay` trait implementation for `embedded-hal` v1.0.0-alpha.5.
+/// `Delay` trait implementation for `embedded-hal` v1.0.0-alpha.7.
 impl Delay {
     /// Constructs a new `Delay`.
     pub fn new() -> Delay {
@@ -46,114 +45,64 @@ impl Delay {
     }
 }
 
-/// `DelayMs<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl DelayMs<u8> for Delay {
-    type Error = Infallible;
-
-    fn delay_ms(&mut self, ms: u8) -> Result<(), Self::Error> {
-        sleep(Duration::from_millis(u64::from(ms)));
-        Ok(())
-    }
-}
-
 /// `DelayMs<u8>` trait implementation for `embedded-hal` v0.2.6.
 impl embedded_hal_0::blocking::delay::DelayMs<u8> for Delay {
     fn delay_ms(&mut self, ms: u8) {
-        DelayMs::delay_ms(self, ms).unwrap()
-    }
-}
-
-/// `DelayMs<u16>` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl DelayMs<u16> for Delay {
-    type Error = Infallible;
-
-    fn delay_ms(&mut self, ms: u16) -> Result<(), Self::Error> {
-        sleep(Duration::from_millis(u64::from(ms)));
-        Ok(())
+        DelayUs::delay_ms(self, ms as u32).unwrap()
     }
 }
 
 /// `DelayMs<u16>` trait implementation for `embedded-hal` v0.2.6.
 impl embedded_hal_0::blocking::delay::DelayMs<u16> for Delay {
     fn delay_ms(&mut self, ms: u16) {
-        DelayMs::delay_ms(self, ms).unwrap()
-    }
-}
-
-/// `DelayMs<u32>` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl DelayMs<u32> for Delay {
-    type Error = Infallible;
-
-    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
-        sleep(Duration::from_millis(u64::from(ms)));
-        Ok(())
+        DelayUs::delay_ms(self, ms as u32).unwrap()
     }
 }
 
 /// `DelayMs<u32>` trait implementation for `embedded-hal` v0.2.6.
 impl embedded_hal_0::blocking::delay::DelayMs<u32> for Delay {
     fn delay_ms(&mut self, ms: u32) {
-        DelayMs::delay_ms(self, ms).unwrap()
-    }
-}
-
-/// `DelayMs<u64>` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl DelayMs<u64> for Delay {
-    type Error = Infallible;
-
-    fn delay_ms(&mut self, ms: u64) -> Result<(), Self::Error> {
-        sleep(Duration::from_millis(ms));
-        Ok(())
+        DelayUs::delay_ms(self, ms).unwrap()
     }
 }
 
 /// `DelayMs<u64>` trait implementation for `embedded-hal` v0.2.6.
 impl embedded_hal_0::blocking::delay::DelayMs<u64> for Delay {
-    fn delay_ms(&mut self, ms: u64) {
-        DelayMs::delay_ms(self, ms).unwrap()
-    }
-}
+    fn delay_ms(&mut self, mut ms: u64) {
+      while ms > (u32::MAX as u64) {
+          ms -= u32::MAX as u64;
+          DelayUs::delay_ms(self, u32::MAX).unwrap();
+      }
 
-/// `DelayUs<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl DelayUs<u8> for Delay {
-    type Error = Infallible;
-
-    fn delay_us(&mut self, us: u8) -> Result<(), Self::Error> {
-        sleep(Duration::from_micros(us.into()));
-        Ok(())
+      DelayUs::delay_ms(self, ms as u32).unwrap()
     }
 }
 
 /// `DelayUs<u8>` trait implementation for `embedded-hal` v0.2.6.
 impl embedded_hal_0::blocking::delay::DelayUs<u8> for Delay {
     fn delay_us(&mut self, us: u8) {
-        DelayUs::delay_us(self, us).unwrap()
-    }
-}
-
-/// `DelayUs<u16>` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl DelayUs<u16> for Delay {
-    type Error = Infallible;
-
-    fn delay_us(&mut self, us: u16) -> Result<(), Self::Error> {
-        sleep(Duration::from_micros(us.into()));
-        Ok(())
+        DelayUs::delay_us(self, us as u32).unwrap()
     }
 }
 
 /// `DelayUs<u16>` trait implementation for `embedded-hal` v0.2.6.
 impl embedded_hal_0::blocking::delay::DelayUs<u16> for Delay {
     fn delay_us(&mut self, us: u16) {
-        DelayUs::delay_us(self, us).unwrap()
+        DelayUs::delay_us(self, us as u32).unwrap()
     }
 }
 
-/// `DelayUs<u32>` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl DelayUs<u32> for Delay {
+/// `DelayUs` trait implementation for `embedded-hal` v1.0.0-alpha.7.
+impl DelayUs for Delay {
     type Error = Infallible;
 
     fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
         sleep(Duration::from_micros(us.into()));
+        Ok(())
+    }
+
+    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
+        sleep(Duration::from_millis(u64::from(ms)));
         Ok(())
     }
 }
@@ -165,20 +114,15 @@ impl embedded_hal_0::blocking::delay::DelayUs<u32> for Delay {
     }
 }
 
-/// `DelayUs<u64>` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl DelayUs<u64> for Delay {
-    type Error = Infallible;
-
-    fn delay_us(&mut self, us: u64) -> Result<(), Self::Error> {
-        sleep(Duration::from_micros(us));
-        Ok(())
-    }
-}
-
 /// `DelayUs<u64>` trait implementation for `embedded-hal` v0.2.6.
 impl embedded_hal_0::blocking::delay::DelayUs<u64> for Delay {
-    fn delay_us(&mut self, us: u64) {
-        DelayUs::delay_us(self, us).unwrap()
+    fn delay_us(&mut self, mut us: u64) {
+        while us > (u32::MAX as u64) {
+            us -= u32::MAX as u64;
+            DelayUs::delay_us(self, u32::MAX).unwrap();
+        }
+
+        DelayUs::delay_us(self, us as u32).unwrap()
     }
 }
 
@@ -220,31 +164,6 @@ impl Default for Timer {
     }
 }
 
-/// `CountDown` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl CountDown for Timer {
-    type Time = Duration;
-    type Error = Infallible;
-
-    /// Starts the timer with a `timeout`.
-    fn start<T>(&mut self, timeout: T) -> Result<(), Self::Error>
-    where
-        T: Into<Self::Time>,
-    {
-        self.start = Instant::now();
-        self.duration = timeout.into();
-        Ok(())
-    }
-
-    /// Returns `Ok` if the timer has wrapped.
-    fn wait(&mut self) -> nb::Result<(), Self::Error> {
-        if self.start.elapsed() >= self.duration {
-            Ok(())
-        } else {
-            Err(nb::Error::WouldBlock)
-        }
-    }
-}
-
 /// `CountDown` trait implementation for `embedded-hal` v0.2.6.
 impl embedded_hal_0::timer::CountDown for Timer {
     type Time = Duration;
@@ -254,7 +173,8 @@ impl embedded_hal_0::timer::CountDown for Timer {
     where
         T: Into<Self::Time>,
     {
-        CountDown::start(self, timeout).unwrap()
+        self.start = Instant::now();
+        self.duration = timeout.into();
     }
 
     /// Returns `Ok` if the timer has wrapped.

--- a/src/i2c/hal.rs
+++ b/src/i2c/hal.rs
@@ -18,40 +18,16 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use embedded_hal::i2c::blocking::{Read, Write, WriteRead};
+use embedded_hal::i2c::{self, ErrorType, blocking::{I2c as I2cHal, Operation as I2cOperation}};
 
 use super::{Error, I2c};
-
-/// `Write` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl Write for I2c {
-    type Error = Error;
-
-    fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        self.set_slave_address(u16::from(address))?;
-        I2c::write(self, bytes)?;
-
-        Ok(())
-    }
-}
 
 /// `Write` trait implementation for `embedded-hal` v0.2.6.
 impl embedded_hal_0::blocking::i2c::Write for I2c {
     type Error = Error;
 
     fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        Write::write(self, address, bytes)
-    }
-}
-
-/// `Read` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl Read for I2c {
-    type Error = Error;
-
-    fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        self.set_slave_address(u16::from(address))?;
-        I2c::read(self, buffer)?;
-
-        Ok(())
+        I2cHal::write(self, address, bytes)
     }
 }
 
@@ -60,24 +36,7 @@ impl embedded_hal_0::blocking::i2c::Read for I2c {
     type Error = Error;
 
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        Read::read(self, address, buffer)
-    }
-}
-
-/// `WriteRead` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl WriteRead for I2c {
-    type Error = Error;
-
-    fn write_read(
-        &mut self,
-        address: u8,
-        bytes: &[u8],
-        buffer: &mut [u8],
-    ) -> Result<(), Self::Error> {
-        self.set_slave_address(u16::from(address))?;
-        I2c::write_read(self, bytes, buffer)?;
-
-        Ok(())
+        I2cHal::read(self, address, buffer)
     }
 }
 
@@ -91,6 +50,94 @@ impl embedded_hal_0::blocking::i2c::WriteRead for I2c {
         bytes: &[u8],
         buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
-        WriteRead::write_read(self, address, bytes, buffer)
+        I2cHal::write_read(self, address, bytes, buffer)
+    }
+}
+
+impl ErrorType for I2c {
+    type Error = Error;
+}
+
+impl i2c::Error for Error {
+    fn kind(&self) -> i2c::ErrorKind {
+        if let Error::Io(e) = self {
+          use std::io::ErrorKind::*;
+
+          match e.kind() {
+            /* ResourceBusy | */ InvalidData => i2c::ErrorKind::Bus,
+            WouldBlock => i2c::ErrorKind::ArbitrationLoss,
+            _ => i2c::ErrorKind::Other,
+          }
+        } else {
+            i2c::ErrorKind::Other
+        }
+    }
+}
+
+/// `I2c` trait implementation for `embedded-hal` v1.0.0-alpha.7.
+impl I2cHal for I2c {
+    fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.set_slave_address(u16::from(address))?;
+        I2c::write(self, bytes)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.set_slave_address(u16::from(address))?;
+        I2c::read(self, buffer)?;
+
+        Ok(())
+    }
+
+    fn write_iter<B>(&mut self, address: u8, bytes: B) -> Result<(), Self::Error>
+    where
+        B: IntoIterator<Item = u8> {
+        let bytes: Vec<_> = bytes.into_iter().collect();
+        I2cHal::write(self, address, &bytes)
+    }
+
+    fn write_read(
+        &mut self,
+        address: u8,
+        bytes: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        self.set_slave_address(u16::from(address))?;
+        I2c::write_read(self, bytes, buffer)?;
+
+        Ok(())
+    }
+
+    fn write_iter_read<B>(
+        &mut self,
+        address: u8,
+        bytes: B,
+        buffer: &mut [u8],
+    ) -> Result<(), Self::Error>
+    where
+        B: IntoIterator<Item = u8>,
+    {
+        let bytes: Vec<_> = bytes.into_iter().collect();
+        self.transaction(
+            address,
+            &mut [I2cOperation::Write(&bytes), I2cOperation::Read(buffer)],
+        )
+    }
+
+    fn transaction(
+        &mut self,
+        _address: u8,
+        _operations: &mut [I2cOperation],
+    ) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+
+    fn transaction_iter<'a, O>(&mut self, address: u8, operations: O) -> Result<(), Self::Error>
+    where
+        O: IntoIterator<Item = I2cOperation<'a>>,
+    {
+        let mut ops: Vec<_> = operations.into_iter().collect();
+        self.transaction(address, &mut ops)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //! The library can be used in conjunction with a variety of platform-agnostic
 //! drivers through its `embedded-hal` trait implementations. Both `embedded-hal`
-//! v0.2.6 and v1.0.0-alpha.5 are supported.
+//! v0.2.6 and v1.0.0-alpha.7 are supported.
 //!
 //! RPPAL requires Raspberry Pi OS or any similar, recent, Linux distribution.
 //! Both `gnu` and `musl` libc targets are supported. RPPAL is compatible with the

--- a/src/pwm/hal.rs
+++ b/src/pwm/hal.rs
@@ -18,105 +18,29 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::time::Duration;
-
-use embedded_hal::pwm::blocking::{Pwm as PwmHal, PwmPin as PwmPinHal};
-
-use super::{Error, Pwm};
-
-/// `Pwm` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl PwmHal for Pwm {
-    type Duty = f64;
-    type Channel = ();
-    type Time = Duration;
-    type Error = Error;
-
-    /// Disables a PWM `channel`.
-    fn disable(&mut self, _channel: &Self::Channel) -> Result<(), Self::Error> {
-        Pwm::disable(self)
-    }
-
-    /// Enables a PWM `channel`.
-    fn enable(&mut self, _channel: &Self::Channel) -> Result<(), Self::Error> {
-        Pwm::enable(self)
-    }
-
-    /// Returns the current PWM period.
-    fn get_period(&self) -> Result<Self::Time, Self::Error> {
-        self.period()
-    }
-
-    /// Returns the current duty cycle.
-    fn get_duty(&self, _channel: &Self::Channel) -> Result<Self::Duty, Self::Error> {
-        self.duty_cycle()
-    }
-
-    /// Returns the maximum duty cycle value.
-    fn get_max_duty(&self) -> Result<Self::Duty, Self::Error> {
-        Ok(1.0)
-    }
-
-    /// Sets a new duty cycle.
-    fn set_duty(&mut self, _channel: &Self::Channel, duty: Self::Duty) -> Result<(), Self::Error> {
-        self.set_duty_cycle(duty)
-    }
-
-    /// Sets a new PWM period.
-    fn set_period<P>(&mut self, period: P) -> Result<(), Self::Error>
-    where
-        P: Into<Self::Time>,
-    {
-        Pwm::set_period(self, period.into())
-    }
-}
-
-/// `PwmPin` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl PwmPinHal for Pwm {
-    type Duty = f64;
-    type Error = Error;
-
-    fn disable(&mut self) -> Result<(), Self::Error> {
-        Pwm::disable(self)
-    }
-
-    fn enable(&mut self) -> Result<(), Self::Error> {
-        Pwm::enable(self)
-    }
-
-    fn get_duty(&self) -> Result<Self::Duty, Self::Error> {
-        self.duty_cycle()
-    }
-
-    fn get_max_duty(&self) -> Result<Self::Duty, Self::Error> {
-        Ok(1.0)
-    }
-
-    fn set_duty(&mut self, duty: Self::Duty) -> Result<(), Self::Error> {
-        self.set_duty_cycle(duty)
-    }
-}
+use super::Pwm;
 
 /// `PwmPin` trait implementation for `embedded-hal` v0.2.6.
 impl embedded_hal_0::PwmPin for Pwm {
     type Duty = f64;
 
     fn disable(&mut self) {
-        let _ = PwmPinHal::disable(self);
+        let _ = Pwm::disable(self);
     }
 
     fn enable(&mut self) {
-        let _ = PwmPinHal::enable(self);
+        let _ = Pwm::enable(self);
     }
 
     fn get_duty(&self) -> Self::Duty {
-        PwmPinHal::get_duty(self).unwrap_or_default()
+        self.duty_cycle().unwrap_or_default()
     }
 
     fn get_max_duty(&self) -> Self::Duty {
-        PwmPinHal::get_max_duty(self).unwrap()
+        1.0
     }
 
     fn set_duty(&mut self, duty: Self::Duty) {
-        let _ = PwmPinHal::set_duty(self, duty);
+        let _ = self.set_duty_cycle(duty);
     }
 }

--- a/src/pwm/hal_unproven.rs
+++ b/src/pwm/hal_unproven.rs
@@ -20,8 +20,6 @@
 
 use std::time::Duration;
 
-use embedded_hal::pwm::blocking::Pwm as PwmHal;
-
 use super::Pwm;
 
 /// Unproven `Pwm` trait implementation for `embedded-hal` v0.2.6.
@@ -31,33 +29,33 @@ impl embedded_hal_0::Pwm for Pwm {
     type Time = Duration;
 
     /// Disables a PWM `channel`.
-    fn disable(&mut self, channel: Self::Channel) {
-        let _ = PwmHal::disable(self, &channel);
+    fn disable(&mut self, _channel: Self::Channel) {
+        let _ = Pwm::disable(self);
     }
 
     /// Enables a PWM `channel`.
-    fn enable(&mut self, channel: Self::Channel) {
-        let _ = PwmHal::enable(self, &channel);
+    fn enable(&mut self, _channel: Self::Channel) {
+        let _ = Pwm::enable(self);
     }
 
     /// Returns the current PWM period.
     fn get_period(&self) -> Self::Time {
-        PwmHal::get_period(self).unwrap_or_default()
+        self.period().unwrap_or_default()
     }
 
     /// Returns the current duty cycle.
-    fn get_duty(&self, channel: Self::Channel) -> Self::Duty {
-        PwmHal::get_duty(self, &channel).unwrap_or_default()
+    fn get_duty(&self, _channel: Self::Channel) -> Self::Duty {
+        self.duty_cycle().unwrap_or_default()
     }
 
     /// Returns the maximum duty cycle value.
     fn get_max_duty(&self) -> Self::Duty {
-        PwmHal::get_max_duty(self).unwrap_or(1.0)
+        1.0
     }
 
     /// Sets a new duty cycle.
-    fn set_duty(&mut self, channel: Self::Channel, duty: Self::Duty) {
-        let _ = PwmHal::set_duty(self, &channel, duty);
+    fn set_duty(&mut self, _channel: Self::Channel, duty: Self::Duty) {
+        let _ = self.set_duty_cycle(duty);
     }
 
     /// Sets a new PWM period.
@@ -65,6 +63,6 @@ impl embedded_hal_0::Pwm for Pwm {
     where
         P: Into<Self::Time>,
     {
-        let _ = PwmHal::set_period(self, period);
+        let _ = Pwm::set_period(self, period.into());
     }
 }

--- a/src/uart/hal.rs
+++ b/src/uart/hal.rs
@@ -18,14 +18,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use embedded_hal::serial::nb::{Read, Write};
+use embedded_hal::serial::{self, ErrorType, nb::{Read, Write}};
 
 use super::{Error, Queue, Uart};
 
-/// `Read<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.5.
-impl Read<u8> for Uart {
+impl ErrorType for Uart {
     type Error = Error;
+}
 
+impl serial::Error for Error {
+  fn kind(&self) -> serial::ErrorKind {
+      serial::ErrorKind::Other
+  }
+}
+
+/// `Read<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.7.
+impl Read<u8> for Uart {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         let mut buffer = [0u8; 1];
         if Uart::read(self, &mut buffer)? == 0 {
@@ -45,10 +53,8 @@ impl embedded_hal_0::serial::Read<u8> for Uart {
     }
 }
 
-/// `Write<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.5.
+/// `Write<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.7.
 impl Write<u8> for Uart {
-    type Error = Error;
-
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
         if Uart::write(self, &[word])? == 0 {
             Err(nb::Error::WouldBlock)


### PR DESCRIPTION
PWM traits have been removed for now, see https://github.com/rust-embedded/embedded-hal/issues/358.

There is a new `transaction` function required for the `I2c` trait. I have not implemented this for now since I don't want to reinvent the wheel. The same functionality is already available via https://github.com/rust-embedded/linux-embedded-hal. Both are using the Linux device, so I don't think there is any difference except implementation details.
