### PR TITLE
Update to embedded-hal version 1.0.0-alpha.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ keywords = ["raspberry", "pi", "embedded-hal", "embedded-hal-impl", "hal"]
 [dependencies]
 libc = "0.2"
 nb = { version = "0.1.1", optional = true }
-embedded-hal-0 = { version = "0.2.6", optional = true, package = "embedded-hal" }
-embedded-hal = { version = "=1.0.0-alpha.7", optional = true }
+embedded-hal-0 = { version = "0.2.7", optional = true, package = "embedded-hal" }
+embedded-hal = { version = "=1.0.0-alpha.8", optional = true }
 void = { version = "1.0.2", optional = true }
 spin_sleep = { version = "1.0.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["raspberry", "pi", "embedded-hal", "embedded-hal-impl", "hal"]
 libc = "0.2"
 nb = { version = "0.1.1", optional = true }
 embedded-hal-0 = { version = "0.2.7", optional = true, package = "embedded-hal" }
-embedded-hal = { version = "=1.0.0-alpha.8", optional = true }
+embedded-hal = { version = "=1.0.0-alpha.9", optional = true }
 void = { version = "1.0.2", optional = true }
 spin_sleep = { version = "1.0.0", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 RPPAL provides access to the Raspberry Pi's GPIO, I2C, PWM, SPI and UART peripherals through a user-friendly interface. In addition to peripheral access, RPPAL also offers support for USB to serial adapters.
 
-The library can be used in conjunction with a variety of platform-agnostic drivers through its `embedded-hal` trait implementations. Both `embedded-hal` v0.2.6 and v1.0.0-alpha.7 are supported.
+The library can be used in conjunction with a variety of platform-agnostic drivers through its `embedded-hal` trait implementations. Both `embedded-hal` v0.2.7 and v1.0.0-alpha.8 are supported.
 
 RPPAL requires Raspberry Pi OS or any similar, recent, Linux distribution. Both `gnu` and `musl` libc targets are supported. RPPAL is compatible with the Raspberry Pi A, A+, B, B+, 2B, 3A+, 3B, 3B+, 4B, CM, CM 3, CM 3+, CM 4, 400, Zero, Zero W and Zero 2 W. Backwards compatibility for minor revisions isn't guaranteed until v1.0.0.
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -147,6 +147,8 @@ mod hal;
 mod ioctl;
 mod segment;
 
+#[cfg(feature = "hal")]
+pub use hal::SimpleHalSpiDevice;
 pub use self::segment::Segment;
 
 /// Errors that can occur when accessing the SPI peripheral.

--- a/src/spi/hal.rs
+++ b/src/spi/hal.rs
@@ -1,11 +1,10 @@
-#![allow(clippy::needless_lifetimes)]
-
 use embedded_hal::spi::nb::FullDuplex;
 use embedded_hal::spi::{
     self,
-    blocking::{Transfer, Write},
+    blocking::{SpiDevice, SpiBus, SpiBusRead, SpiBusWrite, SpiBusFlush},
     ErrorType,
 };
+use std::io;
 
 use super::{Error, Spi};
 
@@ -19,12 +18,17 @@ impl spi::Error for Error {
     }
 }
 
-/// `Transfer<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.7.
-impl Transfer<u8> for Spi {
-    fn transfer<'a>(&mut self, read: &'a mut [u8], write: &[u8]) -> Result<(), Self::Error> {
+/// `Transfer<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.8.
+impl SpiBus<u8> for Spi {
+    fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
         Spi::transfer(self, read, write)?;
 
         Ok(())
+    }
+
+    fn transfer_in_place(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        let write_buffer = buffer.to_vec();
+        self.transfer(buffer, &write_buffer)
     }
 }
 
@@ -34,13 +38,13 @@ impl embedded_hal_0::blocking::spi::Transfer<u8> for Spi {
 
     fn transfer<'a>(&mut self, buffer: &'a mut [u8]) -> Result<&'a [u8], Self::Error> {
         let write_buffer = buffer.to_vec();
-        Transfer::transfer(self, buffer, &write_buffer)?;
+        SpiBus::transfer(self, buffer, &write_buffer)?;
         Ok(buffer)
     }
 }
 
-/// `Write<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.7.
-impl Write<u8> for Spi {
+/// `SpiBusWrite<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.8.
+impl SpiBusWrite<u8> for Spi {
     fn write(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
         Spi::write(self, buffer)?;
 
@@ -53,11 +57,27 @@ impl embedded_hal_0::blocking::spi::Write<u8> for Spi {
     type Error = Error;
 
     fn write(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
-        Write::write(self, buffer)
+        SpiBusWrite::write(self, buffer)
     }
 }
 
-/// `FullDuplex<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.7.
+/// `SpiBusRead<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.8.
+impl SpiBusRead<u8> for Spi {
+    fn read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        Spi::read(self, buffer)?;
+
+        Ok(())
+    }
+}
+
+/// `SpiBusFlush` trait implementation for `embedded-hal` v1.0.0-alpha.8.
+impl SpiBusFlush for Spi {
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// `FullDuplex<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.8.
 impl FullDuplex<u8> for Spi {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         if let Some(last_read) = self.last_read.take() {
@@ -88,4 +108,37 @@ impl embedded_hal_0::spi::FullDuplex<u8> for Spi {
     fn send(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
         FullDuplex::write(self, byte)
     }
+}
+
+/// Simple implementation of [embedded_hal::spi::blocking::SpiDevice]
+///
+/// You only need this when using the `embedded_hal` Spi trait interface.
+///
+/// Slave-select is currently handled at the bus level.
+/// This no-op device implementation can be used to satisfy the trait.
+// TODO: The underlying crate::spi::Spi shall be split up to support proper slave-select handling here.
+pub struct SimpleHalSpiDevice<B> {
+    bus: B,
+}
+
+impl<B> SimpleHalSpiDevice<B> {
+    pub fn new(bus: B) -> SimpleHalSpiDevice<B> {
+        SimpleHalSpiDevice { bus }
+    }
+}
+
+impl<B: ErrorType> SpiDevice for SimpleHalSpiDevice<B> {
+    type Bus = B;
+
+    fn transaction<R>(
+        &mut self,
+        f: impl FnOnce(&mut Self::Bus) -> Result<R, <Self::Bus as ErrorType>::Error>
+    ) -> Result<R, Self::Error> {
+        f(&mut self.bus)
+            .map_err(|_| Error::Io(io::Error::new(io::ErrorKind::Other, "SimpleHalSpiDevice transaction error")))
+    }
+}
+
+impl<B: ErrorType> ErrorType for SimpleHalSpiDevice<B> {
+    type Error = Error;
 }


### PR DESCRIPTION
This PR updates the `embedded-hal` dependency to 1.0.0-alpha.9.

The Spi traits have changed significantly in `embedded-hal` 1.0.0-alpha.8.

`rppal` combines the bus and device (slave select) mechanism into one
`Spi` object. That's not how the new traits in `embedded-hal` alpha 8
work. These require a separation of bus and slave select, to
protect against concurrent access.

We should also forbid transmitting via non-`embedded-hal` methods,
once a transfer over `embedded-hal` trait has been triggered.
Otherwise the protection against concurrent access cannot be
upheld, too.

Therefore, this change is only a first step to get things going with alpha 9.
It does not provide the concurrency protection that the trait demands.
But the new situation after this change is not worse than before this change.