### PR TITLE
Build fixes for 1.0.0-alpha.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ libc = "0.2"
 nb = { version = "0.1.1", optional = true }
 embedded-hal-0 = { version = "0.2.7", optional = true, package = "embedded-hal" }
 embedded-hal = { version = "=1.0.0-alpha.9", optional = true }
+embedded-hal-nb = { version = "=1.0.0-alpha.1", optional = true }
 void = { version = "1.0.2", optional = true }
 spin_sleep = { version = "1.0.0", optional = true }
 
@@ -25,5 +26,5 @@ simple-signal = "1.1.1"
 
 [features]
 default = []
-hal = ["nb", "embedded-hal", "embedded-hal-0", "spin_sleep", "void"]
+hal = ["nb", "embedded-hal", "embedded-hal-nb", "embedded-hal-0", "spin_sleep", "void"]
 hal-unproven = ["nb", "embedded-hal-0/unproven", "hal"]

--- a/src/gpio/hal.rs
+++ b/src/gpio/hal.rs
@@ -1,10 +1,8 @@
 use core::convert::Infallible;
 
 use embedded_hal::digital::{
-    blocking::{
-        InputPin as InputPinHal, OutputPin as OutputPinHal,
-        StatefulOutputPin as StatefulOutputPinHal, ToggleableOutputPin as ToggleableOutputPinHal,
-    },
+    InputPin as InputPinHal, OutputPin as OutputPinHal,
+    StatefulOutputPin as StatefulOutputPinHal, ToggleableOutputPin as ToggleableOutputPinHal,
     ErrorType,
 };
 

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -9,7 +9,7 @@
 use core::convert::Infallible;
 use std::time::{Duration, Instant};
 
-use embedded_hal::delay::blocking::DelayUs;
+use embedded_hal::delay::DelayUs;
 use spin_sleep::sleep;
 use void::Void;
 

--- a/src/i2c/hal.rs
+++ b/src/i2c/hal.rs
@@ -1,6 +1,7 @@
 use embedded_hal::i2c::{
     self,
-    blocking::{I2c as I2cHal, Operation as I2cOperation},
+    I2c as I2cHal,
+    Operation as I2cOperation,
     ErrorType,
 };
 

--- a/src/spi/hal.rs
+++ b/src/spi/hal.rs
@@ -1,8 +1,12 @@
-use embedded_hal::spi::nb::FullDuplex;
+use embedded_hal_nb::spi::FullDuplex;
 use embedded_hal::spi::{
-    self,
-    blocking::{SpiDevice, SpiBus, SpiBusRead, SpiBusWrite, SpiBusFlush},
     ErrorType,
+    SpiBus,
+    SpiBusFlush,
+    SpiBusRead,
+    SpiBusWrite,
+    SpiDevice,
+    self,
 };
 use std::io;
 

--- a/src/uart/hal.rs
+++ b/src/uart/hal.rs
@@ -1,7 +1,10 @@
 use embedded_hal::serial::{
     self,
-    nb::{Read, Write},
     ErrorType,
+};
+use embedded_hal_nb::serial::{
+    Read,
+    Write,
 };
 
 use super::{Error, Queue, Uart};


### PR DESCRIPTION
My recent changes in the PR for 1.0.0-alpha.9 broke some things.
I'm very sorry for that. I should have tested it better.

This PR fixes these build failures.
With this PR applied a `cargo build --examples` succeeds again.