### PR TITLE
Port to embedded-hal 1.0.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ keywords = ["raspberry", "pi", "embedded-hal", "embedded-hal-impl", "hal"]
 libc = "0.2"
 nb = { version = "0.1.1", optional = true }
 embedded-hal-0 = { version = "0.2.7", optional = true, package = "embedded-hal" }
-embedded-hal = { version = "=1.0.0-alpha.10", optional = true }
-embedded-hal-nb = { version = "=1.0.0-alpha.2", optional = true }
+embedded-hal = { version = "=1.0.0-rc.1", optional = true }
+embedded-hal-nb = { version = "=1.0.0-rc.1", optional = true }
 void = { version = "1.0.2", optional = true }
 spin_sleep = { version = "1.0.0", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 RPPAL provides access to the Raspberry Pi's GPIO, I2C, PWM, SPI and UART peripherals through a user-friendly interface. In addition to peripheral access, RPPAL also offers support for USB to serial adapters.
 
-The library can be used in conjunction with a variety of platform-agnostic drivers through its `embedded-hal` trait implementations. Both `embedded-hal` v0.2.7 and v1.0.0-alpha.9 are supported.
+The library can be used in conjunction with a variety of platform-agnostic drivers through its `embedded-hal` trait implementations. Both `embedded-hal` v0.2.7 and v1.0.0-rc.1 are supported.
 
 RPPAL requires Raspberry Pi OS or any similar, recent, Linux distribution. Both `gnu` and `musl` libc targets are supported. RPPAL is compatible with the Raspberry Pi A, A+, B, B+, 2B, 3A+, 3B, 3B+, 4B, 5, CM, CM 3, CM 3+, CM 4, 400, Zero, Zero W and Zero 2 W. Backwards compatibility for minor revisions isn't guaranteed until v1.0.0.
 

--- a/src/gpio/hal.rs
+++ b/src/gpio/hal.rs
@@ -7,12 +7,12 @@ use embedded_hal::digital::{
 
 use super::{InputPin, IoPin, Level, OutputPin, Pin};
 
-/// `ErrorType` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `ErrorType` trait implementation for `embedded-hal` v1.0.0.
 impl ErrorType for Pin {
     type Error = Infallible;
 }
 
-/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `InputPin` trait implementation for `embedded-hal` v1.0.0.
 impl InputPinHal for Pin {
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(Self::read(self) == Level::High)
@@ -23,12 +23,12 @@ impl InputPinHal for Pin {
     }
 }
 
-/// `ErrorType` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `ErrorType` trait implementation for `embedded-hal` v1.0.0.
 impl ErrorType for InputPin {
     type Error = Infallible;
 }
 
-/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `InputPin` trait implementation for `embedded-hal` v1.0.0.
 impl InputPinHal for InputPin {
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(Self::is_high(self))
@@ -39,12 +39,12 @@ impl InputPinHal for InputPin {
     }
 }
 
-/// `ErrorType` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `ErrorType` trait implementation for `embedded-hal` v1.0.0.
 impl ErrorType for IoPin {
     type Error = Infallible;
 }
 
-/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `InputPin` trait implementation for `embedded-hal` v1.0.0.
 impl InputPinHal for IoPin {
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(Self::is_high(self))
@@ -55,12 +55,12 @@ impl InputPinHal for IoPin {
     }
 }
 
-/// `ErrorType` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `ErrorType` trait implementation for `embedded-hal` v1.0.0.
 impl ErrorType for OutputPin {
     type Error = Infallible;
 }
 
-/// `InputPin` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `InputPin` trait implementation for `embedded-hal` v1.0.0.
 impl InputPinHal for OutputPin {
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(Self::is_set_high(self))
@@ -71,7 +71,7 @@ impl InputPinHal for OutputPin {
     }
 }
 
-/// `OutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `OutputPin` trait implementation for `embedded-hal` v1.0.0.
 impl OutputPinHal for OutputPin {
     fn set_low(&mut self) -> Result<(), Self::Error> {
         OutputPin::set_low(self);
@@ -99,7 +99,7 @@ impl embedded_hal_0::digital::v2::OutputPin for OutputPin {
     }
 }
 
-/// `StatefulOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `StatefulOutputPin` trait implementation for `embedded-hal` v1.0.0.
 impl StatefulOutputPinHal for OutputPin {
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         Ok(OutputPin::is_set_high(self))
@@ -110,7 +110,7 @@ impl StatefulOutputPinHal for OutputPin {
     }
 }
 
-/// `ToggleableOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `ToggleableOutputPin` trait implementation for `embedded-hal` v1.0.0.
 impl ToggleableOutputPinHal for OutputPin {
     fn toggle(&mut self) -> Result<(), Self::Error> {
         OutputPin::toggle(self);
@@ -119,7 +119,7 @@ impl ToggleableOutputPinHal for OutputPin {
     }
 }
 
-/// `OutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `OutputPin` trait implementation for `embedded-hal` v1.0.0.
 impl OutputPinHal for IoPin {
     fn set_low(&mut self) -> Result<(), Self::Error> {
         IoPin::set_low(self);
@@ -147,7 +147,7 @@ impl embedded_hal_0::digital::v2::OutputPin for IoPin {
     }
 }
 
-/// `StatefulOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `StatefulOutputPin` trait implementation for `embedded-hal` v1.0.0.
 impl StatefulOutputPinHal for IoPin {
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         Ok(IoPin::is_high(self))
@@ -158,7 +158,7 @@ impl StatefulOutputPinHal for IoPin {
     }
 }
 
-/// `ToggleableOutputPin` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `ToggleableOutputPin` trait implementation for `embedded-hal` v1.0.0.
 impl ToggleableOutputPinHal for IoPin {
     fn toggle(&mut self) -> Result<(), Self::Error> {
         IoPin::toggle(self);

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -16,7 +16,7 @@ use void::Void;
 #[derive(Debug, Default)]
 pub struct Delay;
 
-/// `Delay` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `Delay` trait implementation for `embedded-hal` v1.0.0.
 impl Delay {
     /// Constructs a new `Delay`.
     pub fn new() -> Delay {
@@ -71,7 +71,7 @@ impl embedded_hal_0::blocking::delay::DelayUs<u16> for Delay {
     }
 }
 
-/// `DelayUs` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `DelayUs` trait implementation for `embedded-hal` v1.0.0.
 impl DelayUs for Delay {
     fn delay_us(&mut self, us: u32) {
         sleep(Duration::from_micros(us.into()));

--- a/src/i2c/hal.rs
+++ b/src/i2c/hal.rs
@@ -54,7 +54,7 @@ impl i2c::Error for Error {
     }
 }
 
-/// `I2c` trait implementation for `embedded-hal` v1.0.0-alpha.10.
+/// `I2c` trait implementation for `embedded-hal` v1.0.0.
 impl I2cHal for I2c {
     fn transaction(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! The library can be used in conjunction with a variety of platform-agnostic
 //! drivers through its `embedded-hal` trait implementations. Both `embedded-hal`
-//! v0.2.7 and v1.0.0-alpha.9 are supported.
+//! v0.2.7 and v1.0.0-rc.1 are supported.
 //!
 //! RPPAL requires Raspberry Pi OS or any similar, recent, Linux distribution.
 //! Both `gnu` and `musl` libc targets are supported. RPPAL is compatible with the

--- a/src/uart/hal.rs
+++ b/src/uart/hal.rs
@@ -1,5 +1,4 @@
-use embedded_hal::serial::{self, ErrorType};
-use embedded_hal_nb::serial::{Read, Write};
+use embedded_hal_nb::serial::{self, ErrorType, Read, Write};
 
 use super::{Error, Queue, Uart};
 
@@ -13,7 +12,7 @@ impl serial::Error for Error {
     }
 }
 
-/// `Read<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `Read<u8>` trait implementation for `embedded-hal` v1.0.0.
 impl Read<u8> for Uart {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         let mut buffer = [0u8; 1];
@@ -34,7 +33,7 @@ impl embedded_hal_0::serial::Read<u8> for Uart {
     }
 }
 
-/// `Write<u8>` trait implementation for `embedded-hal` v1.0.0-alpha.9.
+/// `Write<u8>` trait implementation for `embedded-hal` v1.0.0.
 impl Write<u8> for Uart {
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
         if Uart::write(self, &[word])? == 0 {


### PR DESCRIPTION
This updates the rppal to embedded-hal 1.0.0-rc.1.
That is currently the latest released version. (This version is also implemented by esp-idf-hal. Which is good for portability of drivers between rppal and esp)

I tested SPI and I2C communication with rppal on a Raspi 2 with an adxl345 device.

Note:
embedded-hal now suggests to implement the embedded-io traits for uart.
See https://docs.rs/embedded-hal/1.0.0-rc.1/embedded_hal/index.html#serialuart-traits
This is not done with this PR, yet. That can be done later, if required.