### PR TITLE
Add patches to full support "Raspberry PI W2 2021".

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -253,6 +253,7 @@ fn parse_base_compatible() -> Result<Model> {
             "raspberrypi,3-compute-module-plus" => Model::RaspberryPiComputeModule3Plus,
             "raspberrypi,model-zero-w" => Model::RaspberryPiZeroW,
             "raspberrypi,model-zero-2" => Model::RaspberryPiZero2W,
+            "raspberrypi,model-zero-2-w" => Model::RaspberryPiZero2W,
             "raspberrypi,3-model-b-plus" => Model::RaspberryPi3BPlus,
             "raspberrypi,3-model-a-plus" => Model::RaspberryPi3APlus,
             "raspberrypi,4-model-b" => Model::RaspberryPi4B,
@@ -288,6 +289,7 @@ fn parse_base_model() -> Result<Model> {
     match &base_model[..] {
         "Raspberry Pi Model B Rev 2.0" => return Ok(Model::RaspberryPiBRev2),
         "Raspberry Pi Model B rev2 Rev 2.0" => return Ok(Model::RaspberryPiBRev2),
+        "Raspberry Pi Zero 2 W Rev 1.0" => return Ok(Model::RaspberryPiZero2W),
         _ => (),
     }
 
@@ -313,6 +315,7 @@ fn parse_base_model() -> Result<Model> {
         "Raspberry Pi Compute Module 3 Plus" => Model::RaspberryPiComputeModule3Plus,
         "Raspberry Pi Zero W" => Model::RaspberryPiZeroW,
         "Raspberry Pi Zero 2" => Model::RaspberryPiZero2W,
+        "Raspberry Pi Zero 2 W" => Model::RaspberryPiZero2W,
         "Raspberry Pi 3 Model B+" => Model::RaspberryPi3BPlus,
         "Raspberry Pi 3 Model B Plus" => Model::RaspberryPi3BPlus,
         "Raspberry Pi 3 Model A Plus" => Model::RaspberryPi3APlus,


### PR DESCRIPTION
Previously, "Archlinux ARM" images worked fine with your library and identified themselves correctly. With the advent of a distribution update, the operation of your library was disrupted.

According to the new changes to the device tree, devices now identify themselves as "raspberry pi,model-zero-2-w" and there is only one option in your library: "raspberry pi,model-zero-2". ([see current rpios dts file](https://github.com/raspberrypi/linux/blob/f364e0eb8f973e1aa24a3c451d18e84247a8efcd/arch/arm/boot/dts/bcm2710-rpi-zero-2-w.dts#L10C16-L10C42))

Also, here's some debugging:

<b>new_archarm current (0.15.0, Archlinux ARM, W2 2021):</b>
[src/model.rs:173] &hardware[..] = ""
[src/model.rs:174] &revision[..] = "902120"
[src/model.rs:244] comp_id = "raspberrypi,model-zero-2-w"
[src/model.rs:244] comp_id = "brcm,bcm2837"
[src/model.rs:244] comp_id = ""
[src/model.rs:292] &base_model = "Raspberry Pi Zero 2 W Rev 1.0"
[src/model.rs:304] &base_model[..] = "Raspberry Pi Zero 2 W"
cdevice: Err(UnknownModel) **<<**

<b> old_archarm (0.15.0, Archlinux ARM, W2 2021):</b>
[src/model.rs:173] &hardware[..] = "BCM2835"
[src/model.rs:174] &revision[..] = "902120"
[src/model.rs:205] revision_type = 18
cdevice: Ok(DeviceInfo { model: RaspberryPiZero2W, soc: Bcm2837A1, peripheral_base: 1056964608, gpio_offset: 2097152, gpio_lines: 54, gpio_interface: Bcm }) **<<**

<b>current (0.15.0, Archlinux ARM, RPI3):</b>
[src/model.rs:173] &hardware[..] = ""
[src/model.rs:174] &revision[..] = "a02082"
[src/model.rs:244] comp_id = "raspberrypi,3-model-b"
cdevice: Ok(DeviceInfo { model: RaspberryPi3B, soc: Bcm2837A1, peripheral_base: 1056964608, gpio_offset: 2097152, gpio_lines: 54, gpio_interface: Bcm })

<b> next (my_fork, Archlinux ARM, W2 2021):</b>
[src/model.rs:173] &hardware[..] = ""
[src/model.rs:174] &revision[..] = "902120"
[src/model.rs:244] comp_id = "raspberrypi,model-zero-2-w"
[src/model.rs:244] comp_id = "brcm,bcm2837"
[src/model.rs:244] comp_id = ""
[src/model.rs:293] &base_model = "Raspberry Pi Zero 2 W Rev 1.0"
[src/model.rs:305] &base_model[..] = "Raspberry Pi Zero 2 W"
cdevice: Ok(DeviceInfo { model: RaspberryPiZero2W, soc: Bcm2837A1, peripheral_base: 1056964608, gpio_offset: 2097152, gpio_lines: 54, gpio_interface: Bcm })
