### PR TITLE
Fix NULL FUNCSEL handling on Raspberry Pi 5

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -232,6 +232,7 @@ pub enum Mode {
     Alt6,
     Alt7,
     Alt8,
+    Null,
 }
 
 impl fmt::Display for Mode {
@@ -248,6 +249,7 @@ impl fmt::Display for Mode {
             Mode::Alt6 => write!(f, "Alt6"),
             Mode::Alt7 => write!(f, "Alt7"),
             Mode::Alt8 => write!(f, "Alt8"),
+            Mode::Null => write!(f, "Null"),
         }
     }
 }


### PR DESCRIPTION
Fixes #142 

This introduces a new variant to gpio::Mode called `Null` (though something like `Disabled` may be more appropriate - I just stuck with the datasheet).

After implementing this, the example code from #142 gives the following results on a Raspberry Pi 5:

`pinctrl 25` before:
```
25: no    pn | -- // GPIO25 = none
```

`pinctrl 25` after:

```
25: ip    pn | lo // GPIO25 = input
```

And with `set_reset_on_drop(true)`, the pin mode is restored correctly on drop:

`pinctrl 25` before:
```
25: no    pn | -- // GPIO25 = none
```

`pinctrl 25` after:
```
25: no    pn | -- // GPIO25 = none
```

The new variant shouldn't affect anything not using the RP1 (much like `Alt6` - `Alt8` which are also only used in `rp1.rs`)