### PR TITLE
Fix out of bounds with RPi5 extra pwm channels

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -348,7 +348,7 @@ pub struct DeviceInfo {
     // PWM chip # used for hardware PWM on selected GPIO pins
     pwm_chip: u8,
     // PWM channels used for hardware PWM on selected GPIO pins
-    pwm_channels: [u8; 2],
+    pwm_channels: [u8; 4],
 }
 
 impl DeviceInfo {
@@ -379,7 +379,7 @@ impl DeviceInfo {
                 gpio_lines: GPIO_LINES_BCM283X,
                 gpio_interface: GpioInterface::Bcm,
                 pwm_chip: 0,
-                pwm_channels: [0, 1],
+                pwm_channels: [0, 1, 0, 1],
             }),
             Model::RaspberryPi2B => Ok(DeviceInfo {
                 model,
@@ -389,7 +389,7 @@ impl DeviceInfo {
                 gpio_lines: GPIO_LINES_BCM283X,
                 gpio_interface: GpioInterface::Bcm,
                 pwm_chip: 0,
-                pwm_channels: [0, 1],
+                pwm_channels: [0, 1, 0, 1],
             }),
             Model::RaspberryPi3B | Model::RaspberryPiComputeModule3 | Model::RaspberryPiZero2W => {
                 Ok(DeviceInfo {
@@ -400,7 +400,7 @@ impl DeviceInfo {
                     gpio_lines: GPIO_LINES_BCM283X,
                     gpio_interface: GpioInterface::Bcm,
                     pwm_chip: 0,
-                    pwm_channels: [0, 1],
+                    pwm_channels: [0, 1, 0, 1],
                 })
             }
             Model::RaspberryPi3BPlus
@@ -413,7 +413,7 @@ impl DeviceInfo {
                 gpio_lines: GPIO_LINES_BCM283X,
                 gpio_interface: GpioInterface::Bcm,
                 pwm_chip: 0,
-                pwm_channels: [0, 1],
+                pwm_channels: [0, 1, 0, 1],
             }),
             Model::RaspberryPi4B
             | Model::RaspberryPi400
@@ -426,7 +426,7 @@ impl DeviceInfo {
                 gpio_lines: GPIO_LINES_BCM2711,
                 gpio_interface: GpioInterface::Bcm,
                 pwm_chip: 0,
-                pwm_channels: [0, 1],
+                pwm_channels: [0, 1, 0, 1],
             }),
             Model::RaspberryPi5
             | Model::RaspberryPi500
@@ -439,7 +439,7 @@ impl DeviceInfo {
                 gpio_lines: GPIO_LINES_RP1,
                 gpio_interface: GpioInterface::Rp1,
                 pwm_chip: 2,
-                pwm_channels: [2, 3],
+                pwm_channels: [0, 1, 2, 3],
             }),
         }
     }
@@ -480,7 +480,7 @@ impl DeviceInfo {
     }
 
     /// Returns the PWM channels used for hardware PWM.
-    pub(crate) fn pwm_channels(&self) -> [u8; 2] {
+    pub(crate) fn pwm_channels(&self) -> [u8; 4] {
         self.pwm_channels
     }
 }


### PR DESCRIPTION
Our project happened to switch a Raspberry Pi 5 and our hardware PWM stopped working. It seems that there is an out of bounds panic when indexing into the pwm_channels array when using the Channel enum. The 4 channel support was [added](https://github.com/golemparts/rppal/commit/21aec813489155185c6dbc8213833b1f226eb001) yesterday. However now the Channel index can go out of bounds. This makes pwm_channels a [u8; 4]. And when older Pi models attempt to use Channel 2 and 3, they default to 0 and 1 again.

This definitely needs iteration, but I added a temporary fix so we can iterate on it.